### PR TITLE
skip-release: Fix trusted preview image publishing

### DIFF
--- a/.github/workflows/terraform-preview.yaml
+++ b/.github/workflows/terraform-preview.yaml
@@ -200,35 +200,7 @@ jobs:
           BACKEND_TAG: ${{ needs.prepare.outputs.image_tag }}
           FRONTEND_TAG: ${{ needs.prepare.outputs.frontend_image_tag }}
           SKOPEO_IMAGE: quay.io/skopeo/stable:v1.22.2@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615
-        shell: bash
-        run: |
-          set -euo pipefail
-          image_dir="$RUNNER_TEMP/preview-images"
-          auth_file="$HOME/.docker/config.json"
-          test -s "$image_dir/scribe-backend.oci.tar"
-          test -s "$image_dir/scribe-frontend.oci.tar"
-          test -s "$auth_file"
-          skopeo=(
-            docker run --rm --read-only --cap-drop=ALL
-            --security-opt no-new-privileges
-            --tmpfs "/tmp:rw,nosuid,nodev,noexec,size=64m"
-            --tmpfs "/var/tmp:rw,nosuid,nodev,noexec,size=64m"
-            --volume "$image_dir:/images:ro"
-            --volume "$auth_file:/auth/config.json:ro"
-            "$SKOPEO_IMAGE"
-          )
-          "${skopeo[@]}" copy --all --authfile /auth/config.json \
-            oci-archive:/images/scribe-backend.oci.tar "docker://${BACKEND_TAG}"
-          "${skopeo[@]}" copy --all --authfile /auth/config.json \
-            oci-archive:/images/scribe-frontend.oci.tar "docker://${FRONTEND_TAG}"
-          backend_digest="$("${skopeo[@]}" inspect --authfile /auth/config.json --format '{{.Digest}}' "docker://${BACKEND_TAG}")"
-          frontend_digest="$("${skopeo[@]}" inspect --authfile /auth/config.json --format '{{.Digest}}' "docker://${FRONTEND_TAG}")"
-          [[ "$backend_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
-          [[ "$frontend_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
-          {
-            echo "backend_image=${BACKEND_TAG%:*}@${backend_digest}"
-            echo "frontend_image=${FRONTEND_TAG%:*}@${frontend_digest}"
-          } >> "$GITHUB_OUTPUT"
+        run: ./ci/publish-preview-images.sh
   build-ocr:
     if: needs.prepare.outputs.mode == 'apply'
     needs: [prepare, lint-test]

--- a/ci/ops-security-contracts.sh
+++ b/ci/ops-security-contracts.sh
@@ -244,9 +244,14 @@ require_pattern 'frontend-image-smoke\.sh' .github/workflows/terraform-apply.yam
 require_pattern 'frontend-image-smoke\.sh' .github/workflows/terraform-preview.yaml
 require_pattern 'vault-init-image-smoke\.sh' .github/workflows/terraform-apply.yaml
 require_pattern '^  publish-images:' .github/workflows/terraform-preview.yaml
-require_pattern 'oci-archive:/images/scribe-backend\.oci\.tar' .github/workflows/terraform-preview.yaml
-require_pattern 'oci-archive:/images/scribe-frontend\.oci\.tar' .github/workflows/terraform-preview.yaml
+require_pattern 'run: \./ci/publish-preview-images\.sh' .github/workflows/terraform-preview.yaml
+require_pattern 'oci-archive:/images/scribe-backend\.oci\.tar' ci/publish-preview-images.sh
+require_pattern 'oci-archive:/images/scribe-frontend\.oci\.tar' ci/publish-preview-images.sh
+require_pattern 'mktemp -d -- .*scribe-preview-publish\.XXXXXXXXXX' ci/publish-preview-images.sh
+require_pattern '\$\{work_dir\}:/var/tmp:rw' ci/publish-preview-images.sh
+forbid_pattern '--tmpfs .*var/tmp' ci/publish-preview-images.sh
 require_pattern 'quay\.io/skopeo/stable:v[0-9.]+@sha256:[0-9a-f]{64}' .github/workflows/terraform-preview.yaml
+bash ci/publish-preview-images_test.sh
 require_pattern 'terraform output -json deployment_inputs' terraform/deploy-local.sh
 require_pattern 'resolve-destroy-inputs\.sh' terraform/deploy-local.sh
 require_pattern 'deployment-status\.sh' .github/workflows/terraform-deploy.yaml

--- a/ci/publish-preview-images.sh
+++ b/ci/publish-preview-images.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+fail() {
+  echo "preview image publication failed: $*" >&2
+  exit 1
+}
+
+: "${BACKEND_TAG:?BACKEND_TAG is required}"
+: "${FRONTEND_TAG:?FRONTEND_TAG is required}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+: "${HOME:?HOME is required}"
+: "${RUNNER_TEMP:?RUNNER_TEMP is required}"
+: "${SKOPEO_IMAGE:?SKOPEO_IMAGE is required}"
+
+[[ "$BACKEND_TAG" =~ ^ghcr\.io/lehigh-university-libraries/scribe:(pr-[1-9][0-9]*)$ ]] ||
+  fail "BACKEND_TAG must be the Scribe preview GHCR tag"
+preview_tag="${BASH_REMATCH[1]}"
+[[ "$FRONTEND_TAG" == "ghcr.io/lehigh-university-libraries/scribe-frontend:${preview_tag}" ]] ||
+  fail "FRONTEND_TAG must be the matching Scribe frontend preview GHCR tag"
+[[ "$SKOPEO_IMAGE" =~ ^quay\.io/skopeo/stable:v[0-9]+\.[0-9]+\.[0-9]+@sha256:[0-9a-f]{64}$ ]] ||
+  fail "SKOPEO_IMAGE must be a digest-pinned Skopeo stable image"
+
+[[ "$RUNNER_TEMP" == /* && -d "$RUNNER_TEMP" && ! -L "$RUNNER_TEMP" ]] ||
+  fail "RUNNER_TEMP must be an absolute, non-symlink directory"
+runner_temp="$(realpath -e -- "$RUNNER_TEMP")" ||
+  fail "RUNNER_TEMP cannot be resolved"
+[[ "$runner_temp" != "/" ]] || fail "RUNNER_TEMP cannot be the filesystem root"
+
+image_dir="${runner_temp}/preview-images"
+[[ -d "$image_dir" && ! -L "$image_dir" ]] ||
+  fail "preview image directory must be a non-symlink directory"
+[[ "$(realpath -e -- "$image_dir")" == "$image_dir" ]] ||
+  fail "preview image directory must resolve inside RUNNER_TEMP"
+
+validate_archive() {
+  local archive="$1"
+  local resolved
+
+  [[ "$archive" == "${image_dir}/"* && -f "$archive" && -s "$archive" && ! -L "$archive" ]] ||
+    fail "preview OCI archive is missing, empty, or not a regular file: ${archive##*/}"
+  resolved="$(realpath -e -- "$archive")" ||
+    fail "preview OCI archive cannot be resolved: ${archive##*/}"
+  [[ "${resolved%/*}" == "$image_dir" && "$resolved" == "$archive" ]] ||
+    fail "preview OCI archive must resolve directly inside the preview image directory"
+}
+
+backend_archive="${image_dir}/scribe-backend.oci.tar"
+frontend_archive="${image_dir}/scribe-frontend.oci.tar"
+validate_archive "$backend_archive"
+validate_archive "$frontend_archive"
+
+[[ "$HOME" == /* && -d "$HOME" ]] || fail "HOME must be an absolute directory"
+auth_file="${HOME}/.docker/config.json"
+[[ -f "$auth_file" && -s "$auth_file" && ! -L "$auth_file" ]] ||
+  fail "Docker authentication file is missing, empty, or not a regular file"
+auth_file="$(realpath -e -- "$auth_file")" ||
+  fail "Docker authentication file cannot be resolved"
+
+[[ "$GITHUB_OUTPUT" == /* && -f "$GITHUB_OUTPUT" && ! -L "$GITHUB_OUTPUT" && -w "$GITHUB_OUTPUT" ]] ||
+  fail "GITHUB_OUTPUT must be a writable, non-symlink regular file"
+output_file="$(realpath -e -- "$GITHUB_OUTPUT")" ||
+  fail "GITHUB_OUTPUT cannot be resolved"
+[[ "$output_file" == "${runner_temp}/"* ]] ||
+  fail "GITHUB_OUTPUT must resolve inside RUNNER_TEMP"
+
+command -v docker >/dev/null 2>&1 || fail "docker is required"
+
+runtime_uid="$(id -u)"
+runtime_gid="$(id -g)"
+[[ "$runtime_uid" =~ ^[0-9]+$ && "$runtime_gid" =~ ^[0-9]+$ ]] ||
+  fail "runtime UID and GID must be numeric"
+
+umask 077
+work_dir=""
+cleanup() {
+  local status=$?
+  local cleanup_status=0
+  local candidate="${work_dir:-}"
+
+  trap - EXIT
+  if [[ -n "$candidate" ]]; then
+    if [[ "${candidate%/*}" != "$runner_temp" ||
+      ! "${candidate##*/}" =~ ^scribe-preview-publish\.[A-Za-z0-9]{10}$ ||
+      ! -d "$candidate" || -L "$candidate" ]]; then
+      echo "preview image publication cleanup refused an unexpected path" >&2
+      cleanup_status=1
+    elif ! rm -rf --one-file-system -- "$candidate"; then
+      echo "preview image publication could not remove its private temporary directory" >&2
+      cleanup_status=1
+    fi
+  fi
+  if ((status == 0 && cleanup_status != 0)); then
+    status="$cleanup_status"
+  fi
+  exit "$status"
+}
+
+work_dir="$(mktemp -d -- "${runner_temp}/scribe-preview-publish.XXXXXXXXXX")" ||
+  fail "could not create private Skopeo temporary directory"
+trap cleanup EXIT
+[[ "${work_dir%/*}" == "$runner_temp" && -d "$work_dir" && ! -L "$work_dir" ]] ||
+  fail "mktemp returned an unexpected path"
+chmod 0700 -- "$work_dir"
+
+skopeo=(
+  docker run --rm
+  --read-only
+  --cap-drop=ALL
+  --security-opt no-new-privileges
+  --user "${runtime_uid}:${runtime_gid}"
+  --env TMPDIR=/var/tmp
+  --tmpfs "/tmp:rw,nosuid,nodev,noexec,size=64m"
+  --volume "${work_dir}:/var/tmp:rw"
+  --volume "${image_dir}:/images:ro"
+  --volume "${auth_file}:/auth/config.json:ro"
+  "$SKOPEO_IMAGE"
+)
+
+"${skopeo[@]}" copy --all --authfile /auth/config.json \
+  oci-archive:/images/scribe-backend.oci.tar "docker://${BACKEND_TAG}"
+"${skopeo[@]}" copy --all --authfile /auth/config.json \
+  oci-archive:/images/scribe-frontend.oci.tar "docker://${FRONTEND_TAG}"
+
+backend_digest="$("${skopeo[@]}" inspect --authfile /auth/config.json \
+  --format '{{.Digest}}' "docker://${BACKEND_TAG}")"
+frontend_digest="$("${skopeo[@]}" inspect --authfile /auth/config.json \
+  --format '{{.Digest}}' "docker://${FRONTEND_TAG}")"
+[[ "$backend_digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+  fail "Skopeo returned an invalid backend digest"
+[[ "$frontend_digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+  fail "Skopeo returned an invalid frontend digest"
+
+{
+  printf 'backend_image=%s@%s\n' "${BACKEND_TAG%:*}" "$backend_digest"
+  printf 'frontend_image=%s@%s\n' "${FRONTEND_TAG%:*}" "$frontend_digest"
+} >>"$output_file"

--- a/ci/publish-preview-images_test.sh
+++ b/ci/publish-preview-images_test.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+publisher="${repo_root}/ci/publish-preview-images.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+  echo "publish preview images contract failed: $*" >&2
+  exit 1
+}
+
+fake_bin="${tmp}/bin"
+mkdir -p "$fake_bin"
+cat >"${fake_bin}/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+{
+  printf 'call'
+  printf '\t%s' "$@"
+  printf '\n'
+} >>"$DOCKER_LOG"
+
+work_dir=""
+is_inspect=false
+target=""
+for argument in "$@"; do
+  case "$argument" in
+    *:/var/tmp:rw) work_dir="${argument%:/var/tmp:rw}" ;;
+    inspect) is_inspect=true ;;
+    docker://*) target="$argument" ;;
+  esac
+done
+
+[[ -n "$work_dir" && -d "$work_dir" ]] || {
+  echo "missing private /var/tmp bind mount" >&2
+  exit 1
+}
+printf '%s\t%s\n' "$work_dir" "$(stat -c '%a' "$work_dir")" >>"$DOCKER_OBSERVATIONS"
+touch "${work_dir}/mock-skopeo-temporary-file"
+
+if [[ "${DOCKER_FAIL_COPY:-false}" == "true" && "$is_inspect" == "false" ]]; then
+  exit 23
+fi
+
+if "$is_inspect"; then
+  case "$target" in
+    docker://ghcr.io/lehigh-university-libraries/scribe:pr-75)
+      printf 'sha256:%064d\n' 0
+      ;;
+    docker://ghcr.io/lehigh-university-libraries/scribe-frontend:pr-75)
+      printf 'sha256:%064d\n' 1
+      ;;
+    *)
+      echo "unexpected inspect target: $target" >&2
+      exit 1
+      ;;
+  esac
+fi
+EOF
+chmod +x "${fake_bin}/docker"
+
+setup_case() {
+  local name="$1"
+  local root="${tmp}/${name}"
+
+  mkdir -p "${root}/runner/preview-images" "${root}/home/.docker"
+  printf 'backend archive\n' >"${root}/runner/preview-images/scribe-backend.oci.tar"
+  printf 'frontend archive\n' >"${root}/runner/preview-images/scribe-frontend.oci.tar"
+  printf '{"auths":{"ghcr.io":{}}}\n' >"${root}/home/.docker/config.json"
+  : >"${root}/runner/github-output"
+  : >"${root}/docker.log"
+  : >"${root}/docker-observations"
+}
+
+run_publisher() {
+  local root="$1"
+  shift
+
+  env \
+    PATH="${fake_bin}:${PATH}" \
+    HOME="${root}/home" \
+    RUNNER_TEMP="${root}/runner" \
+    GITHUB_OUTPUT="${root}/runner/github-output" \
+    DOCKER_LOG="${root}/docker.log" \
+    DOCKER_OBSERVATIONS="${root}/docker-observations" \
+    BACKEND_TAG="ghcr.io/lehigh-university-libraries/scribe:pr-75" \
+    FRONTEND_TAG="ghcr.io/lehigh-university-libraries/scribe-frontend:pr-75" \
+    SKOPEO_IMAGE="quay.io/skopeo/stable:v1.22.2@sha256:c7d3c512612f52805023cd38351081dad7e2729fc13d14b701e47c7c8bdd6615" \
+    "$@" \
+    "$publisher"
+}
+
+setup_case success
+success_root="${tmp}/success"
+run_publisher "$success_root"
+
+expected_output="$(cat <<'EOF'
+backend_image=ghcr.io/lehigh-university-libraries/scribe@sha256:0000000000000000000000000000000000000000000000000000000000000000
+frontend_image=ghcr.io/lehigh-university-libraries/scribe-frontend@sha256:0000000000000000000000000000000000000000000000000000000000000001
+EOF
+)"
+[[ "$(<"${success_root}/runner/github-output")" == "$expected_output" ]] ||
+  fail "publisher did not emit the expected digest-pinned outputs"
+[[ "$(wc -l <"${success_root}/docker.log")" -eq 4 ]] ||
+  fail "publisher must make exactly two copy and two inspect calls"
+
+for required_argument in \
+  '--read-only' \
+  '--cap-drop=ALL' \
+  'no-new-privileges' \
+  'TMPDIR=/var/tmp' \
+  '/tmp:rw,nosuid,nodev,noexec,size=64m' \
+  "${success_root}/runner/preview-images:/images:ro" \
+  "${success_root}/home/.docker/config.json:/auth/config.json:ro"; do
+  grep -Fq -- "$required_argument" "${success_root}/docker.log" ||
+    fail "Skopeo container is missing required argument: $required_argument"
+done
+grep -Fq -- $'--user\t'"$(id -u):$(id -g)" "${success_root}/docker.log" ||
+  fail "Skopeo container must run as the host runner UID and GID"
+if grep -Fq -- $'--tmpfs\t/var/tmp:' "${success_root}/docker.log"; then
+  fail "/var/tmp must not use a fixed-size tmpfs"
+fi
+
+work_dir="$(cut -f1 "${success_root}/docker-observations" | sort -u)"
+[[ -n "$work_dir" && "$(wc -l <<<"$work_dir")" -eq 1 ]] ||
+  fail "all Skopeo calls must share one private temporary directory"
+[[ "$(cut -f2 "${success_root}/docker-observations" | sort -u)" == "700" ]] ||
+  fail "private Skopeo temporary directory must use mode 0700"
+[[ "$work_dir" == "${success_root}/runner/"scribe-preview-publish.* ]] ||
+  fail "Skopeo temporary directory must be created under RUNNER_TEMP"
+[[ ! -e "$work_dir" ]] || fail "private Skopeo temporary directory was not cleaned"
+
+setup_case copy-failure
+copy_failure_root="${tmp}/copy-failure"
+if run_publisher "$copy_failure_root" \
+  DOCKER_FAIL_COPY=true >"${copy_failure_root}/stdout" 2>"${copy_failure_root}/stderr"; then
+  fail "publisher ignored a Skopeo copy failure"
+fi
+failed_work_dir="$(cut -f1 "${copy_failure_root}/docker-observations" | sort -u)"
+[[ -n "$failed_work_dir" && ! -e "$failed_work_dir" ]] ||
+  fail "private Skopeo temporary directory was not cleaned after failure"
+[[ ! -s "${copy_failure_root}/runner/github-output" ]] ||
+  fail "a failed copy must not publish image outputs"
+
+setup_case invalid-ref
+invalid_ref_root="${tmp}/invalid-ref"
+if run_publisher "$invalid_ref_root" \
+  BACKEND_TAG="ghcr.io/example/attacker:pr-75" >"${invalid_ref_root}/stdout" 2>"${invalid_ref_root}/stderr"; then
+  fail "publisher accepted an unexpected backend registry path"
+fi
+[[ ! -s "${invalid_ref_root}/docker.log" ]] ||
+  fail "invalid image references must fail before Docker runs"
+
+setup_case floating-skopeo
+floating_root="${tmp}/floating-skopeo"
+if run_publisher "$floating_root" \
+  SKOPEO_IMAGE="quay.io/skopeo/stable:v1.22.2" >"${floating_root}/stdout" 2>"${floating_root}/stderr"; then
+  fail "publisher accepted an unpinned Skopeo image"
+fi
+[[ ! -s "${floating_root}/docker.log" ]] ||
+  fail "an unpinned Skopeo image must fail before Docker runs"
+
+setup_case symlink-archive
+symlink_root="${tmp}/symlink-archive"
+mv "${symlink_root}/runner/preview-images/scribe-backend.oci.tar" \
+  "${symlink_root}/runner/backend-outside.oci.tar"
+ln -s "${symlink_root}/runner/backend-outside.oci.tar" \
+  "${symlink_root}/runner/preview-images/scribe-backend.oci.tar"
+if run_publisher "$symlink_root" >"${symlink_root}/stdout" 2>"${symlink_root}/stderr"; then
+  fail "publisher accepted a symlinked OCI archive"
+fi
+[[ ! -s "${symlink_root}/docker.log" ]] ||
+  fail "an invalid archive path must fail before Docker runs"
+
+echo "Publish preview images contracts passed."

--- a/mirador-scribe/package-lock.json
+++ b/mirador-scribe/package-lock.json
@@ -3211,9 +3211,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3396,9 +3396,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -3416,7 +3416,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -28,13 +28,13 @@
       },
       "devDependencies": {
         "@playwright/test": "1.61.1",
-        "@tailwindcss/postcss": "4.3.1",
+        "@tailwindcss/postcss": "4.3.3",
         "@types/node": "24.13.3",
         "@vitejs/plugin-react": "5.2.0",
         "autoprefixer": "10.5.0",
         "happy-dom": "20.10.6",
-        "postcss": "8.5.15",
-        "tailwindcss": "4.3.1",
+        "postcss": "8.5.23",
+        "tailwindcss": "4.3.3",
         "typescript": "5.9.3",
         "vite": "7.3.5",
         "vitest": "4.1.9"
@@ -1956,49 +1956,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
-      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "5.21.6",
+        "enhanced-resolve": "^5.24.1",
         "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.1"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
-      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.1",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
-        "@tailwindcss/oxide-darwin-x64": "4.3.1",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
-      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -2013,9 +2013,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
-      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -2030,9 +2030,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
-      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -2047,9 +2047,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
-      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -2064,9 +2064,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
-      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -2081,9 +2081,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
-      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
@@ -2101,9 +2101,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
-      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
@@ -2121,9 +2121,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
-      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
@@ -2141,9 +2141,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
-      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
@@ -2161,9 +2161,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
-      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -2179,9 +2179,9 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.10.0",
-        "@emnapi/runtime": "^1.10.0",
-        "@emnapi/wasi-threads": "^1.2.1",
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
         "@napi-rs/wasm-runtime": "^1.1.4",
         "@tybys/wasm-util": "^0.10.2",
         "tslib": "^2.8.1"
@@ -2191,18 +2191,18 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
+      "version": "1.11.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
+      "version": "1.11.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2212,7 +2212,7 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2257,9 +2257,9 @@
       "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
-      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -2274,9 +2274,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
-      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -2291,17 +2291,17 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.1.tgz",
-      "integrity": "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.3.1",
-        "@tailwindcss/oxide": "4.3.1",
-        "postcss": "8.5.15",
-        "tailwindcss": "4.3.1"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@types/babel__core": {
@@ -2978,9 +2978,9 @@
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3989,9 +3989,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4206,9 +4206,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -4226,7 +4226,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4935,9 +4935,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
-      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/web/package.json
+++ b/web/package.json
@@ -38,13 +38,13 @@
   },
   "devDependencies": {
     "@playwright/test": "1.61.1",
-    "@tailwindcss/postcss": "4.3.1",
+    "@tailwindcss/postcss": "4.3.3",
     "@types/node": "24.13.3",
     "@vitejs/plugin-react": "5.2.0",
     "autoprefixer": "10.5.0",
     "happy-dom": "20.10.6",
-    "postcss": "8.5.15",
-    "tailwindcss": "4.3.1",
+    "postcss": "8.5.23",
+    "tailwindcss": "4.3.3",
     "typescript": "5.9.3",
     "vite": "7.3.5",
     "vitest": "4.1.9"


### PR DESCRIPTION
Moves Skopeo OCI extraction from the fixed 64 MiB /var/tmp tmpfs to a private disk-backed RUNNER_TEMP workspace through a repository-owned helper, while preserving the read-only, capability-free, non-root container boundary.

Updates the exact Tailwind/PostCSS dependency group to patched versions required by GHSA-r28c-9q8g-f849.

This PRs own Terraform Preview is expected to use the current main workflow and reproduce the issue it fixes. Ordinary CI must pass; the authorized merge will bypass only that self-referential preview check. Release publication is intentionally skipped, while the automatic production apply will still be monitored.