### PR TITLE
[patch] Resolve GAR tags without Container Analysis (skip-release)

### DIFF
--- a/ci/ops-security-contracts.sh
+++ b/ci/ops-security-contracts.sh
@@ -252,6 +252,9 @@ require_pattern '\$\{work_dir\}:/var/tmp:rw' ci/publish-preview-images.sh
 forbid_pattern '--tmpfs .*var/tmp' ci/publish-preview-images.sh
 require_pattern 'quay\.io/skopeo/stable:v[0-9.]+@sha256:[0-9a-f]{64}' .github/workflows/terraform-preview.yaml
 bash ci/publish-preview-images_test.sh
+require_pattern 'artifacts docker tags list' ci/resolve-gar-image.sh
+forbid_pattern 'artifacts docker images describe|containeranalysis' ci/resolve-gar-image.sh
+bash ci/resolve-gar-image_test.sh
 require_pattern 'terraform output -json deployment_inputs' terraform/deploy-local.sh
 require_pattern 'resolve-destroy-inputs\.sh' terraform/deploy-local.sh
 require_pattern 'deployment-status\.sh' .github/workflows/terraform-deploy.yaml

--- a/ci/resolve-gar-image.sh
+++ b/ci/resolve-gar-image.sh
@@ -18,10 +18,18 @@ if [[ ! "$image_ref" =~ ^us-docker\.pkg\.dev/[a-z0-9._/-]+:[A-Za-z0-9_][A-Za-z0-
   exit 1
 fi
 
+image="${image_ref%:*}"
+tag="${image_ref##*:}"
 stderr_file="$(mktemp)"
 trap 'rm -f "$stderr_file"' EXIT
 
-if ! digest="$(gcloud artifacts docker images describe "$image_ref" --format='value(image_summary.digest)' 2>"$stderr_file")"; then
+# The image-description command also queries Container Analysis metadata and
+# therefore needs project-wide occurrence access. Listing tags stays within the
+# repository-scoped Artifact Registry role used by local and CI deploys.
+if ! tags_json="$(
+  gcloud artifacts docker tags list "$image" \
+    --format='json(image,tag,version)' 2>"$stderr_file"
+)"; then
   err_output="$(cat "$stderr_file")"
   if [ -n "$err_output" ]; then
     echo "$err_output" >&2
@@ -30,9 +38,32 @@ if ! digest="$(gcloud artifacts docker images describe "$image_ref" --format='va
   exit 1
 fi
 
+if ! digest="$(
+  jq -er \
+    --arg image "$image" \
+    --arg tag_suffix "/tags/${tag}" \
+    '[
+      .[]
+      | select(
+          .image == $image
+          and (.tag | type == "string")
+          and (.tag | endswith($tag_suffix))
+          and (.version | type == "string")
+        )
+      | .version
+      | split("/versions/")
+      | if length == 2 and .[0] != "" and .[1] != "" then .[1] else empty end
+    ]
+    | if length == 1 then .[0] else empty end' \
+    <<<"$tags_json"
+)"; then
+  echo "failed to resolve digest for Artifact Registry image: $image_ref" >&2
+  exit 1
+fi
+
 if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
   echo "failed to resolve digest for Artifact Registry image: $image_ref" >&2
   exit 1
 fi
 
-printf '%s@%s\n' "${image_ref%:*}" "$digest"
+printf '%s@%s\n' "$image" "$digest"

--- a/ci/resolve-gar-image_test.sh
+++ b/ci/resolve-gar-image_test.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+resolver="${repo_root}/ci/resolve-gar-image.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fail() {
+  echo "GAR image resolver contract failed: $*" >&2
+  exit 1
+}
+
+fake_bin="${tmp}/bin"
+mkdir -p "$fake_bin"
+cat >"${fake_bin}/gcloud" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+{
+  printf 'call'
+  printf '\t%s' "$@"
+  printf '\n'
+} >>"$GCLOUD_LOG"
+
+if [ "${GCLOUD_EXIT:-0}" -ne 0 ]; then
+  echo "mock Artifact Registry failure" >&2
+  exit "$GCLOUD_EXIT"
+fi
+
+printf '%s\n' "${GCLOUD_RESPONSE:-[]}"
+EOF
+chmod +x "${fake_bin}/gcloud"
+
+gcloud_log="${tmp}/gcloud.log"
+: >"$gcloud_log"
+
+run_resolver() {
+  local response="$1"
+  local exit_code="$2"
+  local image_ref="$3"
+
+  env \
+    PATH="${fake_bin}:${PATH}" \
+    GCLOUD_LOG="$gcloud_log" \
+    GCLOUD_RESPONSE="$response" \
+    GCLOUD_EXIT="$exit_code" \
+    "$resolver" "$image_ref"
+}
+
+digest_a="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+digest_b="sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+image="us-docker.pkg.dev/example-project/internal/scribe-frontend"
+tagged_image="${image}:pr-75"
+pinned_image="${image}@${digest_a}"
+
+[[ "$(run_resolver 'invalid' 0 "$pinned_image")" == "$pinned_image" ]] ||
+  fail "an already pinned image was not returned unchanged"
+[[ ! -s "$gcloud_log" ]] ||
+  fail "an already pinned image must not call gcloud"
+
+response="$(
+  jq -cn \
+    --arg image "$image" \
+    --arg digest "$digest_a" \
+    '[{
+      image: $image,
+      tag: "projects/example-project/locations/us/repositories/internal/packages/scribe-frontend/tags/pr-75",
+      version: ("projects/example-project/locations/us/repositories/internal/packages/scribe-frontend/versions/" + $digest)
+    }]'
+)"
+resolved="$(run_resolver "$response" 0 "$tagged_image")"
+[[ "$resolved" == "${image}@${digest_a}" ]] ||
+  fail "the exact GAR tag did not resolve to its immutable digest"
+expected_call=$'call\tartifacts\tdocker\ttags\tlist\t'"${image}"$'\t--format=json(image,tag,version)'
+[[ "$(<"$gcloud_log")" == "$expected_call" ]] ||
+  fail "the resolver did not use the repository-scoped tag listing API"
+
+: >"$gcloud_log"
+nested_image="us-docker.pkg.dev/example-project/internal/team/scribe-frontend"
+nested_response="$(
+  jq -cn \
+    --arg image "$nested_image" \
+    --arg digest "$digest_a" \
+    '[{
+      image: $image,
+      tag: "projects/example-project/locations/us/repositories/internal/packages/team%2Fscribe-frontend/tags/main",
+      version: ("projects/example-project/locations/us/repositories/internal/packages/team%2Fscribe-frontend/versions/" + $digest)
+    }]'
+)"
+[[ "$(
+  run_resolver "$nested_response" 0 "${nested_image}:main"
+)" == "${nested_image}@${digest_a}" ]] ||
+  fail "a nested GAR image path did not resolve"
+
+unrelated_response="$(
+  jq -cn \
+    --arg image "$image" \
+    --arg digest "$digest_a" \
+    '[{
+      image: $image,
+      tag: "projects/example-project/locations/us/repositories/internal/packages/scribe-frontend/tags/pr-750",
+      version: ("projects/example-project/locations/us/repositories/internal/packages/scribe-frontend/versions/" + $digest)
+    }]'
+)"
+if run_resolver "$unrelated_response" 0 "$tagged_image" \
+  >"${tmp}/unrelated.stdout" 2>"${tmp}/unrelated.stderr"; then
+  fail "a different tag was accepted"
+fi
+
+duplicate_response="$(
+  jq -cn \
+    --arg image "$image" \
+    --arg digest_a "$digest_a" \
+    --arg digest_b "$digest_b" \
+    '[
+      {
+        image: $image,
+        tag: "projects/example-project/locations/us/repositories/internal/packages/scribe-frontend/tags/pr-75",
+        version: ("projects/example-project/locations/us/repositories/internal/packages/scribe-frontend/versions/" + $digest_a)
+      },
+      {
+        image: $image,
+        tag: "projects/example-project/locations/us/repositories/internal/packages/scribe-frontend/tags/pr-75",
+        version: ("projects/example-project/locations/us/repositories/internal/packages/scribe-frontend/versions/" + $digest_b)
+      }
+    ]'
+)"
+if run_resolver "$duplicate_response" 0 "$tagged_image" \
+  >"${tmp}/duplicate.stdout" 2>"${tmp}/duplicate.stderr"; then
+  fail "conflicting tag records were accepted"
+fi
+
+malformed_version_response="$(
+  jq -cn \
+    --arg image "$image" \
+    '[{
+      image: $image,
+      tag: "projects/example-project/locations/us/repositories/internal/packages/scribe-frontend/tags/pr-75",
+      version: "projects/example-project/locations/us/repositories/internal/packages/scribe-frontend/versions/latest"
+    }]'
+)"
+for name_and_response in \
+  "missing:[]" \
+  "malformed-version:${malformed_version_response}" \
+  "malformed-json:not-json"; do
+  name="${name_and_response%%:*}"
+  invalid_response="${name_and_response#*:}"
+  if run_resolver "$invalid_response" 0 "$tagged_image" \
+    >"${tmp}/${name}.stdout" 2>"${tmp}/${name}.stderr"; then
+    fail "${name} response was accepted"
+  fi
+  grep -Fq "failed to resolve digest for Artifact Registry image" \
+    "${tmp}/${name}.stderr" ||
+    fail "${name} response did not produce the bounded resolver error"
+  if grep -Fq -- "$invalid_response" "${tmp}/${name}.stderr"; then
+    fail "${name} response contents leaked to stderr"
+  fi
+done
+
+if run_resolver '[]' 23 "$tagged_image" \
+  >"${tmp}/gcloud-failure.stdout" 2>"${tmp}/gcloud-failure.stderr"; then
+  fail "a gcloud failure was ignored"
+fi
+grep -Fq "mock Artifact Registry failure" "${tmp}/gcloud-failure.stderr" ||
+  fail "gcloud diagnostics were not preserved"
+
+: >"$gcloud_log"
+if run_resolver "$response" 0 \
+  "us-docker.pkg.dev/example-project/internal/scribe-frontend@latest" \
+  >"${tmp}/invalid-ref.stdout" 2>"${tmp}/invalid-ref.stderr"; then
+  fail "an invalid digest reference was accepted"
+fi
+[[ ! -s "$gcloud_log" ]] ||
+  fail "an invalid image reference must fail before gcloud runs"
+
+if rg -q 'artifacts docker images describe|containeranalysis' "$resolver"; then
+  fail "the resolver must not require Container Analysis metadata access"
+fi
+
+echo "GAR image resolver contracts passed."


### PR DESCRIPTION
Trusted-main prerequisite for PR #75.

Google Cloud CLI 576 now makes Artifact Registry image description depend on project-wide Container Analysis occurrence access. This replaces that resolver with repository-scoped tag listing, strict immutable-digest selection, and an automated regression contract. No workflow or IAM expansion is needed.

Validation: the same change passed all six exact-head CI jobs on PR #75. This prerequisite PRs own preview is expected to exercise the old protected-main resolver until this commit lands.
