### PR TITLE
[patch] Make fresh preview plans deterministic (skip-release)

### DIFF
--- a/ci/preview-vault-runtime-contract_test.sh
+++ b/ci/preview-vault-runtime-contract_test.sh
@@ -55,6 +55,28 @@ if rg -q '^data "vault_' terraform/vault.tf; then
   fail "a preview plan can still perform a Vault data-source read"
 fi
 
+shared_vault_lookup="$(
+  sed -n '/^data "google_cloud_run_v2_service" "shared_vault" {/,/^}/p' \
+    terraform/main.tf
+)"
+rg -q 'count = local\.vault_is_owner_workspace \? 0 : 1' <<<"$shared_vault_lookup" ||
+  fail "the shared Vault service lookup is not limited to consumer workspaces"
+rg -q 'project[[:space:]]*= var\.project_id' <<<"$shared_vault_lookup" ||
+  fail "the shared Vault service lookup is not project-bound"
+rg -q 'location[[:space:]]*= var\.region' <<<"$shared_vault_lookup" ||
+  fail "the shared Vault service lookup is not region-bound"
+rg -q 'name[[:space:]]*= local\.vault_service_name' <<<"$shared_vault_lookup" ||
+  fail "the shared Vault service lookup does not use the fixed owner name"
+if rg -q '^data "terraform_remote_state" "shared_vault"' terraform/main.tf; then
+  fail "preview Vault discovery still depends on stale owner-workspace root outputs"
+fi
+rg -q 'data\.google_cloud_run_v2_service\.shared_vault\[0\]\.uri' terraform/main.tf ||
+  fail "preview Vault address does not come from the exact live service"
+rg -q 'data\.google_cloud_run_v2_service\.shared_vault\[0\]\.template\[0\]\.service_account' terraform/main.tf ||
+  fail "preview Vault runtime identity does not come from the exact live service"
+rg -q 'local\.vault_gsa == local\.vault_expected_gsa' terraform/main.tf ||
+  fail "preview Vault discovery does not reject runtime identity drift"
+
 preview_policy="$(sed -n '/^resource "vault_policy" "preview_app" {/,/^resource "vault_token_auth_backend_role"/p' terraform/vault.tf)"
 [[ "$(rg -c '^path ' <<<"$preview_policy")" -eq 1 ]] || fail "preview runtime policy must expose exactly one path"
 rg -q 'secret/data/scribe/previews/\{\{identity\.entity\.aliases\.\$\{vault_gcp_auth_backend\.gcp\[0\]\.accessor\}\.metadata\.service_account_email\}\}/database/app' <<<"$preview_policy" ||

--- a/ci/readiness-fixture-test.sh
+++ b/ci/readiness-fixture-test.sh
@@ -37,6 +37,14 @@ grep -Fq 'ocr_readiness_script = file("${local.repo_root}/scripts/ocr-readiness.
   "$ROOT_DIR/terraform/readiness.tf"
 grep -Fq 'name  = "SEGMENTATION_MODEL"' "$ROOT_DIR/terraform/readiness.tf"
 grep -Fq 'value = local.kraken_default_segmentation_key' "$ROOT_DIR/terraform/readiness.tf"
+ocr_readiness_resource="$(
+  sed -n '/^resource "google_cloud_run_v2_job" "ocr_readiness"/,/^}/p' \
+    "$ROOT_DIR/terraform/readiness.tf"
+)"
+grep -Eq '^[[:space:]]*count[[:space:]]*=[[:space:]]*1$' <<<"$ocr_readiness_resource" || {
+  echo "OCR readiness resource count must not depend on newly-created service URLs" >&2
+  exit 1
+}
 grep -Fq 'google_cloud_run_v2_service_iam_member" "ollama_readiness_invoker"' "$ROOT_DIR/terraform/ollama.tf"
 grep -Fq 'name  = "SCRIBE_EXPECTED_BACKEND_IP"' "$ROOT_DIR/terraform/readiness.tf"
 grep -Fq 'value = module.scribe.internal_ip' "$ROOT_DIR/terraform/readiness.tf"

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -332,10 +332,13 @@ optional protected variables `NETWORK_IP_CIDR_RANGE` and
 `COMPOSE_NETWORK_CIDR` must be changed together with an infrastructure review;
 the deployment and drift workflows pass the same values to Terraform.
 
-The shared `dev` Vault state exports both its URL and service-account identity.
-Each preview binds that identity to its own app and VM service accounts with
-metadata-read and public-key-read permissions, allowing Vault GCP IAM login
-without granting key creation, deletion, or access to another workspace.
+Each preview discovers the exact shared `vault-server-dev` Cloud Run service by
+project, region, and fixed name, then binds its runtime identity to the
+preview's app and VM service accounts with metadata-read and public-key-read
+permissions. This direct lookup avoids coupling a fresh preview plan to stale
+or partially upgraded root outputs in the owner workspace while still failing
+closed when the shared service is absent. It allows Vault GCP IAM login without
+granting key creation, deletion, or access to another workspace.
 The shared dev Vault pre-creates one `scribe-preview-app` GCP role and an
 identity-templated policy. The verified GCP alias email renders one exact
 preview database read path, so preview Terraform never creates an auth role or

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,14 +53,12 @@ check "immutable_reviewed_deployment_inputs" {
   }
 }
 
-data "terraform_remote_state" "shared_vault" {
-  count   = local.vault_is_owner_workspace ? 0 : 1
-  backend = "gcs"
-  config = {
-    bucket = local.terraform_state_bucket
-    prefix = "scribe"
-  }
-  workspace = local.shared_vault_workspace
+data "google_cloud_run_v2_service" "shared_vault" {
+  count = local.vault_is_owner_workspace ? 0 : 1
+
+  project  = var.project_id
+  location = var.region
+  name     = local.vault_service_name
 }
 
 data "terraform_remote_state" "shared_foundation" {
@@ -82,8 +80,16 @@ data "terraform_remote_state" "shared_ollama" {
 }
 
 locals {
-  vault_url = local.vault_is_owner_workspace ? module.vault[0].vault-url : try(data.terraform_remote_state.shared_vault[0].outputs.vault_url, "")
-  vault_gsa = local.vault_is_owner_workspace ? module.vault[0].gsa : try(data.terraform_remote_state.shared_vault[0].outputs.vault_gsa, "")
+  # Consumer workspaces discover the exact, already-live shared Vault service
+  # by project, region, and fixed name. This keeps a fresh preview plan
+  # independent of stale or partially-upgraded owner-workspace root outputs.
+  vault_expected_gsa = "${local.vault_service_name}@${var.project_id}.iam.gserviceaccount.com"
+  vault_url = local.vault_is_owner_workspace ? module.vault[0].vault-url : join("", compact([
+    try(data.google_cloud_run_v2_service.shared_vault[0].uri, null),
+  ]))
+  vault_gsa = local.vault_is_owner_workspace ? module.vault[0].gsa : join("", compact([
+    try(data.google_cloud_run_v2_service.shared_vault[0].template[0].service_account, null),
+  ]))
   # Project APIs, the shared registry, and custom roles have a standalone state
   # owner applied before image builds or any application workspace.
   shared_artifact_registry_location   = try(data.terraform_remote_state.shared_foundation.outputs.artifact_registry_location, "")
@@ -563,9 +569,9 @@ resource "google_storage_bucket_iam_member" "uploads_app_object_admin" {
 check "shared_vault_ready" {
   assert {
     condition = local.vault_is_owner_workspace || (
-      trimspace(local.vault_url) != "" && trimspace(local.vault_gsa) != ""
+      trimspace(local.vault_url) != "" && local.vault_gsa == local.vault_expected_gsa
     )
-    error_message = "Shared Vault workspace '${local.shared_vault_workspace}' must be applied first and expose the root outputs 'vault_url' and 'vault_gsa'. Apply the dev workspace before running preview environments."
+    error_message = "Shared Vault workspace '${local.shared_vault_workspace}' must expose a live '${local.vault_service_name}' service with a URL and the expected runtime service account '${local.vault_expected_gsa}' before consumer workspaces can be planned."
   }
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -231,9 +231,9 @@ output "deployment_inputs" {
 
   precondition {
     condition = local.vault_is_owner_workspace || (
-      trimspace(local.vault_url) != "" && trimspace(local.vault_gsa) != ""
+      trimspace(local.vault_url) != "" && local.vault_gsa == local.vault_expected_gsa
     )
-    error_message = "Consumer workspaces require the shared Vault workspace URL and service-account outputs."
+    error_message = "Consumer workspaces require a live shared Vault service URL and its expected fixed runtime service account."
   }
 
   precondition {

--- a/terraform/readiness.tf
+++ b/terraform/readiness.tf
@@ -109,7 +109,9 @@ locals {
 }
 
 resource "google_cloud_run_v2_job" "ocr_readiness" {
-  count = trimspace(local.segmentor_url) != "" && trimspace(local.default_kraken_url) != "" ? 1 : 0
+  # The checked-in OCR catalog requires both services. Keep resource
+  # cardinality plan-time stable when a fresh workspace creates their URLs.
+  count = 1
 
   name                = "${var.name}-${local.workspace_slug}-ocr-readiness"
   location            = var.region


### PR DESCRIPTION
Fixes the fresh-workspace Terraform plan failures exposed by PR #75 after trusted publishing and GAR resolution succeeded.

- Discover the exact shared Vault Cloud Run service directly by protected project, region, and fixed name instead of consuming stale/null dev root outputs.
- Reject Vault runtime service-account drift.
- Keep OCR readiness job cardinality plan-time stable while newly-created endpoint URLs remain computed.
- Add focused contracts and deployment documentation.

Test evidence:
- bash ci/preview-vault-runtime-contract_test.sh
- bash ci/readiness-fixture-test.sh
- make terraform-check
- git diff --check

This is a trusted-main prerequisite for the protected PR #75 preview. The skip-release marker avoids cutting another application release after v0.7.0.