### PR TITLE
[patch] Make preview infrastructure converge (skip-release)

### DIFF
--- a/ci/bootstrap-external-gcp-identities.sh
+++ b/ci/bootstrap-external-gcp-identities.sh
@@ -317,6 +317,7 @@ preview_ocr_member="serviceAccount:$(jq -er '.[] | select(.key == "preview_ocr")
 artifact_writer_members="$(jq -cn --arg prod "$production_ocr_member" --arg preview "$preview_ocr_member" '[$prod, $preview] | sort')"
 artifact_repo_admin_members="$(jq -cn --arg deploy "$preview_deploy_member" '[$deploy]')"
 artifact_publisher_members="$(jq -cn --argjson writers "$artifact_writer_members" --argjson admins "$artifact_repo_admin_members" '$writers + $admins')"
+preview_artifact_policy_role="projects/${GCLOUD_PROJECT}/roles/scribePreviewArtifactPolicy"
 artifact_repository_actions='[]'
 while IFS=$'\t' read -r repository_name repository_format; do
   [[ "$repository_name" =~ /locations/([a-z][a-z0-9-]{0,62})/repositories/([a-z][a-z0-9._-]{1,62}[a-z0-9])$ ]] ||
@@ -347,8 +348,18 @@ while IFS=$'\t' read -r repository_name repository_format; do
       fail "OCR or preview deploy identity has access to non-enumerated GAR repository ${repository_location}/${repository_id}"
     continue
   fi
-  jq -e --arg writer "$ARTIFACT_WRITER_ROLE" --arg admin "roles/artifactregistry.repoAdmin" --arg deploy "$preview_deploy_member" '
-    all(.[]; .condition == null and (if .member == $deploy then .role == $admin else .role == $writer end))
+  jq -e \
+    --arg writer "$ARTIFACT_WRITER_ROLE" \
+    --arg admin "roles/artifactregistry.repoAdmin" \
+    --arg policy_manager "$preview_artifact_policy_role" \
+    --arg deploy "$preview_deploy_member" '
+    all(.[];
+      .condition == null and
+      (if .member == $deploy
+       then (.role == $admin or .role == $policy_manager)
+       else .role == $writer
+       end)
+    )
   ' \
     <<<"$existing_publisher_bindings" >/dev/null ||
     fail "OCR or preview deploy identity has an unexpected role on ${repository_location}/${repository_id}"

--- a/ci/bootstrap-external-gcp-identities_test.sh
+++ b/ci/bootstrap-external-gcp-identities_test.sh
@@ -430,6 +430,16 @@ jq -e --arg member "$PREVIEW_MEMBER" '
   [.bindings[] | select((.members // []) | index($member)) | .role] == ["roles/artifactregistry.repoAdmin"]
 ' "$TEST_DIR/state/artifact-policies/us--internal.json" >/dev/null
 
+# The standalone foundation owns this exact repository-scoped custom role.
+# A later bootstrap run must accept and preserve it rather than rejecting the
+# converged policy or trying to duplicate its ownership.
+preview_artifact_policy_role="projects/${PROJECT}/roles/scribePreviewArtifactPolicy"
+jq --arg member "$PREVIEW_MEMBER" --arg role "$preview_artifact_policy_role" '
+  .bindings += [{role: $role, members: [$member]}] |
+  .bindings |= sort_by(.role, (.condition.expression // ""))
+' "$TEST_DIR/state/artifact-policies/us--internal.json" >"$TEST_DIR/state/artifact-policies/us--internal.tmp"
+mv "$TEST_DIR/state/artifact-policies/us--internal.tmp" "$TEST_DIR/state/artifact-policies/us--internal.json"
+
 # A later production Terraform apply owns these two backup-specific project
 # roles. Bootstrap must accept exactly them while still rejecting broader roles.
 backup_member="serviceAccount:scribe-prod-backup@${PROJECT}.iam.gserviceaccount.com"
@@ -449,8 +459,14 @@ jq -e '
   .actions.state_bucket == {name: "scribe-test1-terraform", versioning: "reuse", soft_delete: "reuse", policy: "reuse"} and
   .actions.notification_channel == "reuse" and
   .artifact_registry.repositories[0].action == "reuse" and
+  .artifact_registry.repositories[0].repo_admin_members == ["serviceAccount:scribe-preview-deploy@scribe-test1.iam.gserviceaccount.com"] and
   all(.actions.identities[]; . == {service_account: "reuse", service_account_policy: "reuse", pool: "reuse", provider: "reuse"})
 ' <<<"$second_plan" >/dev/null
+jq -e --arg member "$PREVIEW_MEMBER" --arg policy_role "$preview_artifact_policy_role" '
+  ([.bindings[] | select((.members // []) | index($member)) | .role] | sort) == ([
+    $policy_role, "roles/artifactregistry.repoAdmin"
+  ] | sort)
+' "$TEST_DIR/state/artifact-policies/us--internal.json" >/dev/null
 assert_no_mutation
 
 cp "$TEST_DIR/state/project-policy.json" "$TEST_DIR/state/project-policy.valid.json"

--- a/ci/cloud-compose-snapshot-contract_test.sh
+++ b/ci/cloud-compose-snapshot-contract_test.sh
@@ -34,6 +34,14 @@ printf '%s\n' "$scribe_module" | grep -Eq 'enabled[[:space:]]*=[[:space:]]*var\.
   fail "Scribe does not pass the reviewed snapshot flag to cloud-compose"
 grep -Eq 'is_prod_workspace[[:space:]]*=[[:space:]]*terraform\.workspace[[:space:]]*==[[:space:]]*"prod"' terraform/main.tf ||
   fail "the production workspace predicate is not exact"
+grep -Eq 'cloud_compose_machine_type[[:space:]]*=[[:space:]]*local\.is_preview_workspace[[:space:]]*\?[[:space:]]*"e2-medium"[[:space:]]*:[[:space:]]*var\.machine_type' terraform/main.tf ||
+  fail "previews do not use the reviewed E2 machine profile"
+grep -Eq 'cloud_compose_disk_type[[:space:]]*=[[:space:]]*local\.is_preview_workspace[[:space:]]*\?[[:space:]]*"pd-standard"[[:space:]]*:[[:space:]]*"hyperdisk-balanced"' terraform/main.tf ||
+  fail "previews still consume production Hyperdisk capacity"
+printf '%s\n' "$scribe_module" | grep -Eq 'machine_type[[:space:]]*=[[:space:]]*local\.cloud_compose_machine_type' ||
+  fail "Scribe does not pass the workspace-specific machine profile to cloud-compose"
+printf '%s\n' "$scribe_module" | grep -Eq 'type[[:space:]]*=[[:space:]]*local\.cloud_compose_disk_type' ||
+  fail "Scribe does not pass the workspace-specific disk profile to cloud-compose"
 
 grep -Eq 'production[[:space:]]*=[[:space:]]*optional\(bool,[[:space:]]*false\)' "$module_variables" ||
   fail "the initialized cloud-compose production default changed"

--- a/ci/project-foundation-contract_test.sh
+++ b/ci/project-foundation-contract_test.sh
@@ -53,6 +53,7 @@ printf '%s\n' "$preview_policy_binding" | grep -Eq 'repository[[:space:]]*=[[:sp
   fail "preview repository-policy role is not scoped to the foundation repository"
 printf '%s\n' "$preview_policy_binding" | grep -Eq 'role[[:space:]]*=[[:space:]]*google_project_iam_custom_role\.preview_artifact_registry_policy_manager\.name' ||
   fail "preview repository-policy binding does not use the two-permission custom role"
+# shellcheck disable=SC2016 # Match the literal Terraform interpolation.
 printf '%s\n' "$preview_policy_binding" | grep -Fq 'member     = "serviceAccount:${local.preview_deploy_service_account_email}"' ||
   fail "preview repository-policy role is not bound to the deterministic preview deploy identity"
 

--- a/ci/project-foundation-contract_test.sh
+++ b/ci/project-foundation-contract_test.sh
@@ -15,6 +15,10 @@ grep -Eq 'source[[:space:]]*=[[:space:]]*"https://github.com/libops/cloud-compos
   fail "foundation does not pin libops/cloud-compose by immutable commit"
 grep -q 'resource "google_artifact_registry_repository" "internal"' terraform/foundation/main.tf ||
   fail "foundation does not own the pre-build Artifact Registry repository"
+grep -q 'resource "google_project_iam_custom_role" "preview_artifact_registry_policy_manager"' terraform/foundation/main.tf ||
+  fail "foundation does not own the preview repository-policy role"
+grep -q 'resource "google_artifact_registry_repository_iam_member" "preview_deploy_policy_manager"' terraform/foundation/main.tf ||
+  fail "foundation does not bind the preview repository-policy role"
 grep -q 'resource "google_project_iam_custom_role" "vault_gcp_auth_key_verifier"' terraform/foundation/main.tf ||
   fail "foundation does not own the Vault verifier role"
 grep -q 'resource "google_project_iam_custom_role" "cloud_compose_observe"' terraform/foundation/main.tf ||
@@ -30,6 +34,27 @@ printf '%s\n' "$control_plane_service" | grep -Eq 'disable_on_destroy[[:space:]]
   fail "control-plane APIs can be disabled on state removal"
 printf '%s\n' "$control_plane_service" | grep -Eq 'deletion_policy[[:space:]]*=[[:space:]]*"ABANDON"' ||
   fail "control-plane APIs are not abandoned on state removal"
+
+preview_policy_role="$(sed -n '/^resource "google_project_iam_custom_role" "preview_artifact_registry_policy_manager" {/,/^}/p' terraform/foundation/main.tf)"
+preview_policy_permissions="$(printf '%s\n' "$preview_policy_role" |
+  sed -n '/^[[:space:]]*permissions[[:space:]]*=[[:space:]]*\[/,/^[[:space:]]*\]/p' |
+  sed -n 's/.*"\([^"]*\)".*/\1/p' |
+  sort)"
+[ "$preview_policy_permissions" = "artifactregistry.repositories.getIamPolicy
+artifactregistry.repositories.setIamPolicy" ] ||
+  fail "preview repository-policy role must contain only getIamPolicy and setIamPolicy"
+printf '%s\n' "$preview_policy_role" | grep -Eq 'deletion_policy[[:space:]]*=[[:space:]]*"PREVENT"' ||
+  fail "preview repository-policy role can be deleted with foundation state"
+
+preview_policy_binding="$(sed -n '/^resource "google_artifact_registry_repository_iam_member" "preview_deploy_policy_manager" {/,/^}/p' terraform/foundation/main.tf)"
+printf '%s\n' "$preview_policy_binding" | grep -Eq 'location[[:space:]]*=[[:space:]]*google_artifact_registry_repository\.internal\.location' ||
+  fail "preview repository-policy role is not scoped to the foundation registry location"
+printf '%s\n' "$preview_policy_binding" | grep -Eq 'repository[[:space:]]*=[[:space:]]*google_artifact_registry_repository\.internal\.repository_id' ||
+  fail "preview repository-policy role is not scoped to the foundation repository"
+printf '%s\n' "$preview_policy_binding" | grep -Eq 'role[[:space:]]*=[[:space:]]*google_project_iam_custom_role\.preview_artifact_registry_policy_manager\.name' ||
+  fail "preview repository-policy binding does not use the two-permission custom role"
+printf '%s\n' "$preview_policy_binding" | grep -Fq 'member     = "serviceAccount:${local.preview_deploy_service_account_email}"' ||
+  fail "preview repository-policy role is not bound to the deterministic preview deploy identity"
 
 foundation_state="$(sed -n '/^data "terraform_remote_state" "shared_foundation" {/,/^}/p' terraform/main.tf)"
 printf '%s\n' "$foundation_state" | grep -Eq 'prefix[[:space:]]*=[[:space:]]*local\.foundation_state_prefix' ||

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -224,9 +224,13 @@ removes project-policy mutation from preview Terraform is the required target.
 OCR writer access is
 repository-level and limited to `artifact_registry.ocr_publish_repositories`
 in `config/ocr.yaml`; project-wide or non-enumerated repository access fails.
-The preview deploy identity receives `roles/artifactregistry.repoAdmin` only on
-those same repositories so Terraform can maintain repository IAM without a
-project-wide Artifact Registry role.
+The preview deploy identity currently receives
+`roles/artifactregistry.repoAdmin` only on those same repositories for the
+protected preview image path. That built-in role includes artifact deletion but
+does not include repository IAM-policy access. The standalone foundation adds
+the separate two-permission custom role described below; reducing the legacy
+publication grant to `roles/artifactregistry.writer` requires an explicit live
+IAM migration.
 An existing backup identity may have only bootstrap viewer roles plus the
 Terraform-managed Storage Transfer viewer and `scribeBackupRestoreVerifier`
 custom role. Policy writes retain etags so concurrent IAM changes fail.
@@ -359,6 +363,14 @@ Management with `disable_on_destroy = false` and
 `deletion_policy = "ABANDON"`, so removing them from state leaves both APIs
 enabled. The manual plan path does not perform that bootstrap or any other API
 mutation. Dev, production, and previews only consume the foundation outputs.
+The foundation also grants the protected preview deploy identity a custom role
+containing only `artifactregistry.repositories.getIamPolicy` and
+`artifactregistry.repositories.setIamPolicy`, and binds it only on the
+reviewed `us/internal` repository. The built-in repository administrator role
+does not contain those IAM-policy permissions, but Cloud Compose needs them to
+converge each preview VM's repository-reader member. Keeping the two policy
+permissions in a repository-scoped custom role avoids granting project-wide
+Artifact Registry administration.
 
 Vault uses separate runtime and initializer Google service accounts. Runtime
 can access only the data bucket; initializer alone can access initialization
@@ -556,6 +568,12 @@ production VM. Upgrade COS only by reviewing and pinning a Cloud Compose release
 that changes that image. Terraform then replaces the boot disk and VM while
 reattaching the stable data and Docker-volume disks; Scribe does not maintain a
 second host-operating-system path.
+
+Production and development use the reviewed N4/Hyperdisk Balanced profile.
+Ephemeral pull-request previews still run COS, but use `e2-medium` with Standard
+Persistent Disk. That profile keeps preview disks out of the finite production
+Hyperdisk capacity pool while preserving the same Cloud Compose bootstrap,
+separate data and Docker-volume disks, and teardown path.
 
 The Compose checkout is workspace-stable at
 `/mnt/disks/data/scribe/<workspace>`, even though every deployment fetches,

--- a/terraform/foundation/main.tf
+++ b/terraform/foundation/main.tf
@@ -7,8 +7,9 @@ provider "google-beta" {
 }
 
 locals {
-  artifact_registry_location   = "us"
-  artifact_registry_repository = "internal"
+  artifact_registry_location           = "us"
+  artifact_registry_repository         = "internal"
+  preview_deploy_service_account_email = "scribe-preview-deploy@${var.project_id}.iam.gserviceaccount.com"
   control_plane_services = toset([
     "servicemanagement.googleapis.com",
     "serviceusage.googleapis.com",
@@ -67,6 +68,32 @@ resource "google_artifact_registry_repository" "internal" {
   }
 
   depends_on = [google_project_service.artifact_registry]
+}
+
+resource "google_project_iam_custom_role" "preview_artifact_registry_policy_manager" {
+  project     = var.project_id
+  role_id     = "scribePreviewArtifactPolicy"
+  title       = "Scribe Preview Artifact Policy Manager"
+  description = "Allows protected preview Terraform to reconcile VM reader access on the single reviewed Artifact Registry repository."
+  permissions = [
+    "artifactregistry.repositories.getIamPolicy",
+    "artifactregistry.repositories.setIamPolicy",
+  ]
+  stage = "GA"
+
+  deletion_policy = "PREVENT"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_artifact_registry_repository_iam_member" "preview_deploy_policy_manager" {
+  project    = var.project_id
+  location   = google_artifact_registry_repository.internal.location
+  repository = google_artifact_registry_repository.internal.repository_id
+  role       = google_project_iam_custom_role.preview_artifact_registry_policy_manager.name
+  member     = "serviceAccount:${local.preview_deploy_service_account_email}"
 }
 
 resource "google_project_iam_custom_role" "vault_gcp_auth_key_verifier" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,22 +22,23 @@ data "google_project" "current" {
 }
 
 locals {
-  project_number           = tostring(data.google_project.current.number)
-  repo_root                = abspath("${path.module}/..")
-  disk_type                = "hyperdisk-balanced"
-  terraform_state_bucket   = trimspace(var.terraform_state_bucket) != "" ? trimspace(var.terraform_state_bucket) : "${var.project_id}-terraform"
-  is_prod_workspace        = terraform.workspace == "prod"
-  is_preview_workspace     = startswith(terraform.workspace, "pr-")
-  foundation_state_prefix  = "scribe-foundation"
-  shared_vault_workspace   = local.is_prod_workspace ? "prod" : "dev"
-  shared_ollama_workspace  = "prod"
-  vault_is_owner_workspace = terraform.workspace == "prod" || terraform.workspace == "dev"
-  workspace_slug           = replace(lower(terraform.workspace), "/[^a-z0-9-]+/", "-")
-  preview_app_gsa_email    = format("%s@%s.iam.gserviceaccount.com", var.name, var.project_id)
-  vault_app_role_name      = local.is_preview_workspace ? "scribe-preview-app" : "scribe-app-${local.workspace_slug}"
-  vault_secret_prefix      = local.is_preview_workspace ? "scribe/previews/${local.preview_app_gsa_email}" : "scribe/${local.workspace_slug}"
-  pubsub_service_agent     = "service-${local.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
-  uploads_bucket_name      = trimsuffix(substr(replace(lower("${var.project_id}-${var.name}-${local.workspace_slug}-uploads"), "/[^a-z0-9._-]/", "-"), 0, 63), "-")
+  project_number             = tostring(data.google_project.current.number)
+  repo_root                  = abspath("${path.module}/..")
+  terraform_state_bucket     = trimspace(var.terraform_state_bucket) != "" ? trimspace(var.terraform_state_bucket) : "${var.project_id}-terraform"
+  is_prod_workspace          = terraform.workspace == "prod"
+  is_preview_workspace       = startswith(terraform.workspace, "pr-")
+  cloud_compose_machine_type = local.is_preview_workspace ? "e2-medium" : var.machine_type
+  cloud_compose_disk_type    = local.is_preview_workspace ? "pd-standard" : "hyperdisk-balanced"
+  foundation_state_prefix    = "scribe-foundation"
+  shared_vault_workspace     = local.is_prod_workspace ? "prod" : "dev"
+  shared_ollama_workspace    = "prod"
+  vault_is_owner_workspace   = terraform.workspace == "prod" || terraform.workspace == "dev"
+  workspace_slug             = replace(lower(terraform.workspace), "/[^a-z0-9-]+/", "-")
+  preview_app_gsa_email      = format("%s@%s.iam.gserviceaccount.com", var.name, var.project_id)
+  vault_app_role_name        = local.is_preview_workspace ? "scribe-preview-app" : "scribe-app-${local.workspace_slug}"
+  vault_secret_prefix        = local.is_preview_workspace ? "scribe/previews/${local.preview_app_gsa_email}" : "scribe/${local.workspace_slug}"
+  pubsub_service_agent       = "service-${local.project_number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+  uploads_bucket_name        = trimsuffix(substr(replace(lower("${var.project_id}-${var.name}-${local.workspace_slug}-uploads"), "/[^a-z0-9._-]/", "-"), 0, 63), "-")
 }
 
 check "immutable_reviewed_deployment_inputs" {
@@ -637,12 +638,12 @@ module "scribe" {
     instance = {
       # Cloud Compose's GCP runtime is COS. Host lifecycle scripts are tested
       # against the jq and shell feature set shipped by that image.
-      machine_type = var.machine_type
+      machine_type = local.cloud_compose_machine_type
       production   = local.is_prod_workspace
     }
 
     disks = {
-      type                   = local.disk_type
+      type                   = local.cloud_compose_disk_type
       data_size_gb           = local.cloud_compose_data_disk_size_gb
       docker_volumes_size_gb = var.disk_size_gb
     }


### PR DESCRIPTION
Fix the two blockers exposed by the fresh PR #75 preview apply.

- grant the preview deploy identity only repository IAM get/set through a foundation-owned custom role scoped to `us/internal`
- preserve bootstrap convergence with that exact foundation role
- run PR previews on COS with the upstream-supported `e2-medium` + `pd-standard` profile, leaving dev/prod N4 + Hyperdisk unchanged

Focused evidence:
- `make terraform-check`
- `make terraform-state-normalizer-test`
- `make terraform-targeted-output-test`
- `make ops-security-contracts`
- foundation init/validate
- `git diff --check`

This is a trusted-main prerequisite for PR #75; `skip-release` intentionally preserves v0.7.0.