### PR TITLE
[patch] Isolate preview VM placement (skip-release)

### DIFF
--- a/.github/workflows/terraform-preview.yaml
+++ b/.github/workflows/terraform-preview.yaml
@@ -49,7 +49,7 @@ jobs:
     env:
       GCLOUD_PROJECT: ${{ vars.GCLOUD_PROJECT }}
       SCRIBE_REGION: ${{ vars.SCRIBE_REGION != '' && vars.SCRIBE_REGION || 'us-east5' }}
-      SCRIBE_ZONE: ${{ vars.SCRIBE_ZONE != '' && vars.SCRIBE_ZONE || 'us-east5-b' }}
+      SCRIBE_ZONE: ${{ vars.SCRIBE_PREVIEW_ZONE != '' && vars.SCRIBE_PREVIEW_ZONE || 'us-east5-c' }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout protected preview orchestration

--- a/ci/deploy-local-destroy_test.sh
+++ b/ci/deploy-local-destroy_test.sh
@@ -145,10 +145,12 @@ run_destroy() {
     GCLOUD_PROJECT=example-project \
     TF_STATE_BUCKET=example-state \
     ALLOWED_IPS='["127.0.0.1/32"]' \
+    SCRIBE_REGION=caller-region1 \
+    SCRIBE_ZONE=caller-region1-a \
     VAULT_TOKEN=test-only-token \
     TF_TEST_COMMAND_LOG="${command_log}" \
     TF_TEST_LOG="${terraform_log}" \
-    TF_TEST_STATE_FILE="${state_file}" \
+    TF_TEST_STATE_FILE="${TF_TEST_STATE_FILE:-$state_file}" \
     TF_TEST_STATE_MODE="${mode}" \
     TF_TEST_WORKSPACE_MODE="${TF_TEST_WORKSPACE_MODE:-existing}" \
     "${ROOT_DIR}/terraform/deploy-local.sh" preview destroy \
@@ -192,6 +194,8 @@ grep -F -- '-var=docker_compose_branch=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 grep -F -- '-var=data_generation=canonical-v1' "${terraform_log}" >/dev/null
 grep -F -- '-var=api_image=ghcr.io/lehigh-university-libraries/scribe@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' "${terraform_log}" >/dev/null
 grep -F -- '-var=frontend_gar_image=us-docker.pkg.dev/example-project/internal/scribe-frontend@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc' "${terraform_log}" >/dev/null
+grep -F -- '-var=region=us-east5' "${terraform_log}" >/dev/null
+grep -F -- '-var=zone=us-east5-b' "${terraform_log}" >/dev/null
 if grep -F -- '-var=frontend_image=' "${terraform_log}" >/dev/null; then
   echo "destroy replayed an unused GHCR frontend image into Terraform" >&2
   exit 1
@@ -214,6 +218,25 @@ for mode in corrupt missing; do
     echo "corrupt state content leaked to stderr" >&2
     exit 1
   fi
+done
+
+for invalid_zone in not-a-zone us-west1-a; do
+  invalid_state="${TEST_DIR}/deployment-inputs-${invalid_zone}.json"
+  jq --arg zone "$invalid_zone" '.configuration.zone = $zone' \
+    "${state_file}" >"${invalid_state}"
+  : >"${terraform_log}"
+  if TF_TEST_STATE_FILE="$invalid_state" run_destroy valid \
+    "${TEST_DIR}/invalid-zone-${invalid_zone}.out" \
+    "${TEST_DIR}/invalid-zone-${invalid_zone}.err"; then
+    echo "destroy unexpectedly accepted invalid recorded zone ${invalid_zone}" >&2
+    exit 1
+  fi
+  if grep -F 'destroy -auto-approve' "${terraform_log}" >/dev/null; then
+    echo "destroy ran with invalid recorded zone ${invalid_zone}" >&2
+    exit 1
+  fi
+  grep -F 'Inspect and recover the remote workspace state before retrying destroy.' \
+    "${TEST_DIR}/invalid-zone-${invalid_zone}.err" >/dev/null
 done
 
 : >"${terraform_log}"

--- a/ci/resolve-destroy-inputs.sh
+++ b/ci/resolve-destroy-inputs.sh
@@ -16,6 +16,12 @@ if ! jq -ceS \
   --arg zero_digest "$zero_digest" '
     select(
     type == "object" and
+    (.configuration as $configuration |
+      $configuration | type == "object" and
+      (.project_id == $project) and
+      (.region | type == "string" and test("^[a-z]+-[a-z]+[0-9]+$")) and
+      (.zone | type == "string" and test("^[a-z]+-[a-z]+[0-9]+-[a-z]$")) and
+      (.zone | startswith($configuration.region + "-"))) and
     (.data_generation | type == "string" and test("^[a-z][a-z0-9-]{0,31}$")) and
     (.docker_compose_sha | type == "string" and test("^[0-9a-f]{40}$") and . != $zero_sha) and
     (.api_image |

--- a/ci/resolve-preview-inputs_test.sh
+++ b/ci/resolve-preview-inputs_test.sh
@@ -71,6 +71,7 @@ grep -F "vars.SCRIBE_ZONE != '' && vars.SCRIBE_ZONE || 'us-east5-b'" \
   exit 1
 }
 preview_local_fallback="$(
+  # shellcheck disable=SC2016 # Match the deploy helper's literal preview-mode condition.
   sed -n '/if \[ "${environment:-}" = "preview" \]; then/,/^[[:space:]]*fi$/p' \
     "${ROOT_DIR}/terraform/deploy-local.sh"
 )"

--- a/ci/resolve-preview-inputs_test.sh
+++ b/ci/resolve-preview-inputs_test.sh
@@ -33,7 +33,7 @@ run_event_case() {
     GITHUB_REPOSITORY="example/scribe" \
     GCLOUD_PROJECT="example-project" \
     SCRIBE_REGION="us-east5" \
-    SCRIBE_ZONE="us-east5-b" \
+    SCRIBE_ZONE="us-east5-c" \
     EVENT_ACTION="${action}" \
     EVENT_BASE_REF="${base_ref}" \
     EVENT_PREVIOUS_BASE_REF="${previous_base_ref}" \
@@ -44,6 +44,8 @@ run_event_case() {
 
   grep -Fx "mode=${expected_mode}" "${output_file}" >/dev/null
   grep -Fx "base_sha=${main_sha}" "${output_file}" >/dev/null
+  grep -Fx "zone=us-east5-c" "${output_file}" >/dev/null
+  grep -Fx "backend_origin=http://scribe-pr-75.us-east5-c.c.example-project.internal" "${output_file}" >/dev/null
   grep -Fx "frontend_gar_image_tag=us-docker.pkg.dev/example-project/internal/scribe-frontend:pr-75" "${output_file}" >/dev/null
   if grep -q '^frontend_gar_image=' "${output_file}"; then
     echo "Preview resolver emitted an unused untagged frontend GAR repository" >&2
@@ -57,6 +59,23 @@ run_event_case edited feature main destroy
 workflow="${ROOT_DIR}/.github/workflows/terraform-preview.yaml"
 grep -F './ci/resolve-preview-inputs.sh' "${workflow}" >/dev/null || {
   echo "Terraform Preview must use the tested trusted-input resolver" >&2
+  exit 1
+}
+grep -F "vars.SCRIBE_PREVIEW_ZONE != '' && vars.SCRIBE_PREVIEW_ZONE || 'us-east5-c'" "${workflow}" >/dev/null || {
+  echo "Terraform Preview must use its protected preview-only zone default" >&2
+  exit 1
+}
+grep -F "vars.SCRIBE_ZONE != '' && vars.SCRIBE_ZONE || 'us-east5-b'" \
+  "${ROOT_DIR}/.github/workflows/terraform-apply.yaml" >/dev/null || {
+  echo "Terraform Apply must retain the production zone default" >&2
+  exit 1
+}
+preview_local_fallback="$(
+  sed -n '/if \[ "${environment:-}" = "preview" \]; then/,/^[[:space:]]*fi$/p' \
+    "${ROOT_DIR}/terraform/deploy-local.sh"
+)"
+grep -F "printf 'us-east5-c\\n'" <<<"$preview_local_fallback" >/dev/null || {
+  echo "Local preview deploys must share the GitHub preview zone default" >&2
   exit 1
 }
 if grep -F 'github.event.pull_request.base.sha' "${workflow}" >/dev/null; then

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -575,6 +575,16 @@ Persistent Disk. That profile keeps preview disks out of the finite production
 Hyperdisk capacity pool while preserving the same Cloud Compose bootstrap,
 separate data and Docker-volume disks, and teardown path.
 
+Production defaults to `us-east5-b`; pull-request previews use the separate
+`us-east5-c` placement default so preview capacity does not contend with the
+production VM's zone. Set the protected repository variable
+`SCRIBE_PREVIEW_ZONE` to another E2-capable zone in the configured region when
+preview placement must change. Local preview commands use the same `us-east5-c`
+default and accept `SCRIBE_ZONE` as an explicit override. Changing a preview's zone replaces its
+three ephemeral zonal disks. Refresh and destroy always replay the region and
+zone recorded in that workspace's deployment inputs instead of guessing from
+the current default.
+
 The Compose checkout is workspace-stable at
 `/mnt/disks/data/scribe/<workspace>`, even though every deployment fetches,
 detaches to, and verifies a different immutable commit. Do not run `git pull`

--- a/terraform/deploy-local.sh
+++ b/terraform/deploy-local.sh
@@ -25,7 +25,7 @@ Optional environment:
   SCRIBE_OCR_IMAGES_JSON  Pre-resolved JSON map of OCR service_key -> GAR digest ref. For plan/apply only; refresh and destroy reload the recorded map from Terraform state.
   SCRIBE_DATA_GENERATION  Reviewed persistence generation. Defaults to canonical-v1; refresh and destroy always reload the recorded value from Terraform state.
   SCRIBE_OCR_IMAGE_TAG    Tag to resolve against when generating the OCR image map locally. Defaults to the immutable --branch commit SHA for production and preview, and the branch slug for development.
-  SCRIBE_ZONE            Optional zone override used when locally building the frontend GAR sidecar. Falls back to TF_VAR_zone, terraform/terraform.tfvars, then us-east5-b.
+  SCRIBE_ZONE            Optional zone override used when locally building the frontend GAR sidecar. Falls back to TF_VAR_zone, terraform/terraform.tfvars, then us-east5-c for previews or us-east5-b otherwise.
   SCRIBE_REGION          Optional region override. Falls back to TF_VAR_region, then us-east5.
   VAULT_ADMIN_EMAILS      Optional Terraform list(string) for vault_admin_emails, e.g. ["you@example.edu"].
   VAULT_CI_SERVICE_ACCOUNT_EMAILS  Optional Terraform list(string) for vault_ci_service_account_emails, e.g. ["github@project.iam.gserviceaccount.com"].
@@ -96,6 +96,11 @@ resolve_terraform_zone() {
       printf '%s\n' "$from_tfvars"
       return 0
     fi
+  fi
+
+  if [ "${environment:-}" = "preview" ]; then
+    printf 'us-east5-c\n'
+    return 0
   fi
 
   printf 'us-east5-b\n'
@@ -684,6 +689,11 @@ if [ "$action" = "destroy" ] || [ "$action" = "refresh" ]; then
   frontend_gar_image_tag="$(jq -r '.frontend_gar_image' <<<"$stored_deployment_inputs")"
   ocr_images_json="$(jq -c '.ocr_service_images' <<<"$stored_deployment_inputs")"
   data_generation="$(jq -r '.data_generation' <<<"$stored_deployment_inputs")"
+  TF_VAR_region="$(jq -r '.configuration.region' <<<"$stored_deployment_inputs")"
+  TF_VAR_zone="$(jq -r '.configuration.zone' <<<"$stored_deployment_inputs")"
+  SCRIBE_REGION="$TF_VAR_region"
+  SCRIBE_ZONE="$TF_VAR_zone"
+  export SCRIBE_REGION SCRIBE_ZONE TF_VAR_region TF_VAR_zone
   if [ "$action" = "refresh" ]; then
     ALLOWED_IPS="$(jq -c '.configuration.allowed_ips' <<<"$stored_deployment_inputs")"
     ALLOWED_SSH_IPV4="$(jq -c '.configuration.allowed_ssh_ipv4' <<<"$stored_deployment_inputs")"
@@ -696,7 +706,6 @@ if [ "$action" = "destroy" ] || [ "$action" = "refresh" ]; then
     TF_VAR_iiif_max_manifest_import_bytes="$(jq -r '.configuration.iiif_max_manifest_import_bytes' <<<"$stored_deployment_inputs")"
     TF_VAR_monitoring_notification_channels="$(jq -c '.configuration.monitoring_notification_channels' <<<"$stored_deployment_inputs")"
     TF_VAR_network_ip_cidr_range="$(jq -r '.configuration.network_ip_cidr_range' <<<"$stored_deployment_inputs")"
-    TF_VAR_region="$(jq -r '.configuration.region' <<<"$stored_deployment_inputs")"
     TF_VAR_storage_max_bytes_per_workspace="$(jq -r '.configuration.storage_max_bytes_per_workspace' <<<"$stored_deployment_inputs")"
     TF_VAR_storage_max_bytes_total="$(jq -r '.configuration.storage_max_bytes_total' <<<"$stored_deployment_inputs")"
     TF_VAR_storage_max_images_per_workspace="$(jq -r '.configuration.storage_max_images_per_workspace' <<<"$stored_deployment_inputs")"
@@ -707,19 +716,15 @@ if [ "$action" = "destroy" ] || [ "$action" = "refresh" ]; then
     TF_VAR_storage_normalization_cache_max_bytes="$(jq -r '.configuration.storage_normalization_cache_max_bytes' <<<"$stored_deployment_inputs")"
     TF_VAR_storage_reservation_ttl="$(jq -r '.configuration.storage_reservation_ttl' <<<"$stored_deployment_inputs")"
     TF_VAR_transcription_max_active_jobs_per_workspace="$(jq -r '.configuration.transcription_max_active_jobs_per_workspace' <<<"$stored_deployment_inputs")"
-    TF_VAR_zone="$(jq -r '.configuration.zone' <<<"$stored_deployment_inputs")"
-    SCRIBE_REGION="$TF_VAR_region"
-    SCRIBE_ZONE="$TF_VAR_zone"
     export ALLOWED_IPS ALLOWED_SSH_IPV4 ALLOWED_SSH_IPV6 VAULT_ADMIN_EMAILS VAULT_CI_SERVICE_ACCOUNT_EMAILS
-    export SCRIBE_REGION SCRIBE_ZONE
     export TF_VAR_backup_restore_service_account_email TF_VAR_compose_network_cidr
     export TF_VAR_iiif_max_manifest_canvases TF_VAR_iiif_max_manifest_import_bytes
-    export TF_VAR_monitoring_notification_channels TF_VAR_network_ip_cidr_range TF_VAR_region
+    export TF_VAR_monitoring_notification_channels TF_VAR_network_ip_cidr_range
     export TF_VAR_storage_max_bytes_per_workspace TF_VAR_storage_max_bytes_total
     export TF_VAR_storage_max_images_per_workspace TF_VAR_storage_max_images_total
     export TF_VAR_storage_max_items_per_workspace TF_VAR_storage_max_items_total
     export TF_VAR_storage_normalization_cache_max_age TF_VAR_storage_normalization_cache_max_bytes
-    export TF_VAR_storage_reservation_ttl TF_VAR_transcription_max_active_jobs_per_workspace TF_VAR_zone
+    export TF_VAR_storage_reservation_ttl TF_VAR_transcription_max_active_jobs_per_workspace
     if [ "$environment" = "prod" ]; then
       BACKUP_AUDIT_SCOPE=state "$repo_root/ci/verify-cloud-backups.sh"
       export TF_VAR_terraform_state_backup_audited=true


### PR DESCRIPTION
Moves pull-request previews to a separately configurable us-east5-c default after repeated e2-medium capacity exhaustion in the production VM zone. Production remains on us-east5-b. The shared local deploy path uses the same preview default, while refresh/destroy replay the exact recorded region and zone and reject invalid state.

Validation:
- bash ci/resolve-preview-inputs_test.sh
- bash ci/deploy-local-destroy_test.sh
- make preview-deployment-test
- make ops-security-contracts
- pinned ShellCheck 0.11.0 on changed scripts
- actionlint on apply/preview workflows
- git diff --check

Residual live evidence: protected Terraform Preview must prove us-east5-c capacity and zonal replacement.