### PR TITLE
Lock external hOCR quota accounting

### DIFF
--- a/internal/server/process_hocr_idempotency_test.go
+++ b/internal/server/process_hocr_idempotency_test.go
@@ -3,9 +3,12 @@ package server
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/lehigh-university-libraries/scribe/internal/auth"
@@ -13,6 +16,184 @@ import (
 	scribev1 "github.com/lehigh-university-libraries/scribe/proto/scribe/v1"
 	"google.golang.org/protobuf/proto"
 )
+
+func TestProcessHOCRExternalImageURLReservesZeroBlobBytesAndDoesNotInflateQuota(t *testing.T) {
+	database := openTestDB(t)
+	workspaceID, userID := createServerTestWorkspace(t, database)
+	ocrRuns := store.NewOCRRunStore(database)
+	items := store.NewItemStore(database)
+	contexts := store.NewContextStore(database)
+	annotations := store.NewAnnotationStore(database)
+	jobs := store.NewTranscriptionJobStore(database)
+	handler := NewHandler(ocrRuns, items, contexts, annotations, jobs, &auth.Manager{}, nil, nil)
+	requestCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx := auth.WithPrincipal(requestCtx, auth.Principal{
+		Authenticated: true,
+		UserID:        userID,
+		WorkspaceID:   workspaceID,
+		WorkspaceRole: "write",
+	})
+	usageBefore, err := items.GetStorageQuotaUsage(ctx, workspaceID)
+	if err != nil {
+		t.Fatalf("load storage quota before ProcessHOCR: %v", err)
+	}
+
+	// Hold the membership row after ProcessHOCR creates its quota reservation
+	// but before the canonical ingest can commit. This makes the transient
+	// reservation directly observable without adding a production-only seam.
+	blocker, err := database.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin ProcessHOCR quota observer: %v", err)
+	}
+	blockerCommitted := false
+	defer func() {
+		if !blockerCommitted {
+			_ = blocker.Rollback()
+		}
+	}()
+	var role string
+	if err := blocker.QueryRowContext(ctx, `
+SELECT role
+FROM workspace_members
+WHERE workspace_id = ? AND user_id = ?
+FOR UPDATE`, workspaceID, userID).Scan(&role); err != nil {
+		t.Fatalf("lock ProcessHOCR workspace membership: %v", err)
+	}
+
+	request := &scribev1.ProcessHOCRRequest{
+		Hocr:           minimalHOCR,
+		ImageUrl:       "https://images.example.test/external-hocr.jpg",
+		IdempotencyKey: "process-hocr-external-zero-blob-quota",
+	}
+	type processResult struct {
+		response *connect.Response[scribev1.ProcessHOCRResponse]
+		err      error
+	}
+	resultCh := make(chan processResult, 1)
+	go func() {
+		response, processErr := handler.ProcessHOCR(ctx, connect.NewRequest(request))
+		resultCh <- processResult{response: response, err: processErr}
+	}()
+
+	var (
+		reservedBlobBytes     uint64
+		reservedDatabaseBytes uint64
+		reservedItems         uint64
+		reservedImages        uint64
+		resourceKey           sql.NullString
+	)
+	reservationDeadline := time.Now().Add(10 * time.Second)
+	for {
+		err = database.QueryRowContext(ctx, `
+SELECT reserved_bytes, reserved_database_bytes, reserved_items, reserved_images, resource_key
+FROM workspace_storage_reservations
+WHERE workspace_id = ?`, workspaceID).Scan(
+			&reservedBlobBytes,
+			&reservedDatabaseBytes,
+			&reservedItems,
+			&reservedImages,
+			&resourceKey,
+		)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			t.Fatalf("inspect ProcessHOCR storage reservation: %v", err)
+		}
+		select {
+		case result := <-resultCh:
+			t.Fatalf("ProcessHOCR completed before quota inspection: response=%v error=%v", result.response, result.err)
+		default:
+		}
+		if time.Now().After(reservationDeadline) {
+			t.Fatal("timed out waiting for ProcessHOCR storage reservation")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if reservedBlobBytes != 0 || reservedDatabaseBytes != 0 || reservedItems != 1 || reservedImages != 1 || resourceKey.Valid {
+		t.Fatalf(
+			"external hOCR reservation = blob:%d database:%d items:%d images:%d resource:%q/%t, want 0/0/1/1/unbound",
+			reservedBlobBytes,
+			reservedDatabaseBytes,
+			reservedItems,
+			reservedImages,
+			resourceKey.String,
+			resourceKey.Valid,
+		)
+	}
+	usageDuring, err := items.GetStorageQuotaUsage(ctx, workspaceID)
+	if err != nil {
+		t.Fatalf("load storage quota during ProcessHOCR: %v", err)
+	}
+	if usageDuring.ReservedUploadBlobBytes != usageBefore.ReservedUploadBlobBytes ||
+		usageDuring.ReservedDatabaseBytes != usageBefore.ReservedDatabaseBytes ||
+		usageDuring.ReservedItems != usageBefore.ReservedItems+1 ||
+		usageDuring.ReservedImages != usageBefore.ReservedImages+1 {
+		t.Fatalf("external hOCR in-flight quota = before %+v / during %+v", usageBefore, usageDuring)
+	}
+
+	if err := blocker.Commit(); err != nil {
+		t.Fatalf("release ProcessHOCR quota observer: %v", err)
+	}
+	blockerCommitted = true
+	var first *connect.Response[scribev1.ProcessHOCRResponse]
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("ProcessHOCR external image URL: %v", result.err)
+		}
+		first = result.response
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for ProcessHOCR after quota inspection")
+	}
+	t.Cleanup(func() {
+		_ = items.DeleteForWorkspace(context.Background(), first.Msg.GetItemId(), workspaceID)
+	})
+
+	persistedImage, err := items.GetImageForWorkspace(ctx, first.Msg.GetItemImageId(), workspaceID)
+	if err != nil {
+		t.Fatalf("load external hOCR image: %v", err)
+	}
+	if persistedImage.ImageURL != request.GetImageUrl() || persistedImage.StorageBytes != 0 {
+		t.Fatalf("external hOCR image storage = %+v, want original URL with zero owned bytes", persistedImage)
+	}
+	usageAfter, err := items.GetStorageQuotaUsage(ctx, workspaceID)
+	if err != nil {
+		t.Fatalf("load storage quota after ProcessHOCR: %v", err)
+	}
+	if usageAfter.UploadBlobBytes != usageBefore.UploadBlobBytes ||
+		usageAfter.ReservedUploadBlobBytes != usageBefore.ReservedUploadBlobBytes ||
+		usageAfter.ReservedDatabaseBytes != usageBefore.ReservedDatabaseBytes ||
+		usageAfter.ReservedItems != usageBefore.ReservedItems ||
+		usageAfter.ReservedImages != usageBefore.ReservedImages ||
+		usageAfter.Items != usageBefore.Items+1 ||
+		usageAfter.Images != usageBefore.Images+1 ||
+		usageAfter.DatabaseBytes <= usageBefore.DatabaseBytes {
+		t.Fatalf("external hOCR committed quota = before %+v / after %+v", usageBefore, usageAfter)
+	}
+
+	replayed, err := handler.ProcessHOCR(ctx, connect.NewRequest(request))
+	if err != nil {
+		t.Fatalf("replay external hOCR import: %v", err)
+	}
+	if replayed.Msg.GetItemId() != first.Msg.GetItemId() || replayed.Msg.GetItemImageId() != first.Msg.GetItemImageId() {
+		t.Fatalf(
+			"replayed external hOCR IDs = %q/%d, want %q/%d",
+			replayed.Msg.GetItemId(),
+			replayed.Msg.GetItemImageId(),
+			first.Msg.GetItemId(),
+			first.Msg.GetItemImageId(),
+		)
+	}
+	usageAfterReplay, err := items.GetStorageQuotaUsage(ctx, workspaceID)
+	if err != nil {
+		t.Fatalf("load storage quota after external hOCR replay: %v", err)
+	}
+	if usageAfterReplay != usageAfter {
+		t.Fatalf("external hOCR replay inflated quota = before %+v / after %+v", usageAfter, usageAfterReplay)
+	}
+}
 
 func TestProcessHOCRCommitsAndReplaysOneIdempotentResult(t *testing.T) {
 	database := openTestDB(t)

--- a/mirador-scribe/src/plugins/documentEventBridges.test.jsx
+++ b/mirador-scribe/src/plugins/documentEventBridges.test.jsx
@@ -88,7 +88,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('document editor event bridges', () => {
+describe('document event bridges', () => {
   it('registers once, routes through the latest callback, and removes the exact listener', () => {
     const addListener = vi.spyOn(document, 'addEventListener');
     const removeListener = vi.spyOn(document, 'removeEventListener');


### PR DESCRIPTION
## Summary

- prove external ProcessHOCR image URLs reserve zero upload-blob bytes while retaining item and image quota accounting
- verify durable quota state and exact idempotent replay after ingestion
- rename the collective document-event bridge suite to match its coverage

## Validation

- `make ci`