### PR TITLE
[skip-release] Route preview browser readiness over IPv6

### DIFF
--- a/Dockerfile.browser-readiness
+++ b/Dockerfile.browser-readiness
@@ -13,6 +13,7 @@ FROM mcr.microsoft.com/playwright:v1.62.0-noble@sha256:baed2032d533817f3dbe6425d
 WORKDIR /app
 
 COPY --from=dependencies --chown=pwuser:pwuser /app/node_modules ./node_modules
+COPY --chown=pwuser:pwuser web/e2e/deployed-readiness-routing.mjs ./deployed-readiness-routing.mjs
 COPY --chown=pwuser:pwuser web/e2e/deployed-readiness.mjs ./deployed-readiness.mjs
 
 USER pwuser

--- a/ci/browser-readiness-contract_test.sh
+++ b/ci/browser-readiness-contract_test.sh
@@ -49,11 +49,14 @@ require_fixed 'ENTRYPOINT ["node", "/app/deployed-readiness.mjs"]' Dockerfile.br
 require_fixed 'COPY web/package.json web/package-lock.json ./' Dockerfile.browser-readiness
 require_fixed 'RUN npm ci --ignore-scripts --prefer-offline --no-audit' Dockerfile.browser-readiness
 require_fixed 'COPY --chown=pwuser:pwuser web/e2e/deployed-readiness.mjs ./deployed-readiness.mjs' Dockerfile.browser-readiness
+require_fixed 'COPY --chown=pwuser:pwuser web/e2e/deployed-readiness-routing.mjs ./deployed-readiness-routing.mjs' Dockerfile.browser-readiness
 forbid_pattern 'readiness-smoke\.png\.base64' Dockerfile.browser-readiness
 require_fixed 'gha-creds-*.json' .dockerignore
 forbid_pattern 'latest|curl|wget|apt-get' Dockerfile.browser-readiness
 [ "$(rg -c -F 'COPY --chown=pwuser:pwuser web/e2e/deployed-readiness.mjs ./deployed-readiness.mjs' Dockerfile.browser-readiness)" -eq 1 ] ||
   fail "the protected Dockerfile must copy the PR-head script exactly once"
+[ "$(rg -c -F 'COPY --chown=pwuser:pwuser web/e2e/deployed-readiness-routing.mjs ./deployed-readiness-routing.mjs' Dockerfile.browser-readiness)" -eq 1 ] ||
+  fail "the protected Dockerfile must copy the IPv6 routing helper exactly once"
 assert_before Dockerfile.browser-readiness '^RUN npm ci --ignore-scripts' '^COPY --chown=pwuser:pwuser web/e2e/deployed-readiness\.mjs'
 final_image_stage="$(awk '/^FROM / { stage += 1 } stage == 2 { print }' Dockerfile.browser-readiness)"
 if rg -q '^RUN[[:space:]]' <<<"$final_image_stage"; then
@@ -64,6 +67,19 @@ bash ci/prepare-browser-readiness-source_test.sh
 forbid_pattern 'readiness-smoke\.png\.base64' ci/prepare-browser-readiness-source.sh
 
 node --check web/e2e/deployed-readiness.mjs
+node --test web/e2e/deployed-readiness-routing_test.mjs
+require_fixed 'configureCanonicalIPv6Routing(baseURL.hostname)' web/e2e/deployed-readiness.mjs
+require_fixed 'args: [chromiumIPv6Argument]' web/e2e/deployed-readiness.mjs
+require_fixed 'options.setResultOrder ?? setDefaultResultOrder' web/e2e/deployed-readiness-routing.mjs
+require_fixed 'setResultOrder("ipv6first")' web/e2e/deployed-readiness-routing.mjs
+require_fixed 'options.setAutoSelectFamily ?? setDefaultAutoSelectFamily' web/e2e/deployed-readiness-routing.mjs
+require_fixed 'setAutoSelectFamily(false)' web/e2e/deployed-readiness-routing.mjs
+require_fixed 'Object.freeze(["8.8.8.8", "8.8.4.4"])' web/e2e/deployed-readiness-routing.mjs
+require_fixed 'resolver.setServers([...publicDNSResolvers])' web/e2e/deployed-readiness-routing.mjs
+require_fixed 'const defaultResolutionTimeoutMs = 120_000;' web/e2e/deployed-readiness-routing.mjs
+require_fixed 'const defaultResolutionAttemptTimeoutMs = 10_000;' web/e2e/deployed-readiness-routing.mjs
+require_fixed 'const defaultResolutionRetryIntervalMs = 2_000;' web/e2e/deployed-readiness-routing.mjs
+require_fixed 'if (!address) throw new Error("canonical IPv6 resolution timed out");' web/e2e/deployed-readiness-routing.mjs
 require_fixed 'import { createHash, randomUUID } from "node:crypto";' web/e2e/deployed-readiness.mjs
 require_fixed 'const readinessSmokeFixtureSHA256 = "e3f3bb2b5ade3c15af262a76ad58b720e7eb3b3d079802df04f1dd50be917b2d";' web/e2e/deployed-readiness.mjs
 require_fixed 'const fixture = Buffer.from(readinessSmokeFixtureBase64, "base64");' web/e2e/deployed-readiness.mjs
@@ -483,6 +499,9 @@ require_fixed 'substr("probe-browser-${local.workspace_slug}", 0, 21)' terraform
 for resource in google_compute_address google_compute_router google_compute_router_nat google_compute_subnetwork google_cloud_run_v2_job google_service_account; do
   require_pattern "resource \"${resource}\" \"browser_readiness\"" terraform/readiness.tf
 done
+for resource in google_compute_address google_compute_network google_compute_router google_compute_router_nat google_compute_subnetwork; do
+  require_pattern "resource \"${resource}\" \"browser_readiness_ipv6\"" terraform/readiness.tf
+done
 for required in \
   'nat_ip_allocate_option             = "MANUAL_ONLY"' \
   'nat_ips                            = [google_compute_address.browser_readiness[0].self_link]' \
@@ -491,21 +510,54 @@ for required in \
   'source_ip_ranges_to_nat = ["ALL_IP_RANGES"]' \
   'service_account = google_service_account.browser_readiness[0].email' \
   'egress = "ALL_TRAFFIC"' \
-  'subnetwork = local.browser_readiness_subnetwork_resource_name' \
   'value = local.public_base_url'; do
   require_fixed "$required" terraform/readiness.tf
 done
+require_fixed 'value = "--dns-result-order=ipv6first --no-network-family-autoselection"' terraform/readiness.tf
+for required in \
+  'auto_create_subnetworks = false' \
+  'routing_mode            = "REGIONAL"' \
+  'mtu                     = 1460' \
+  'network                  = google_compute_network.browser_readiness_ipv6[0].self_link' \
+  'stack_type               = "IPV4_IPV6"' \
+  'ipv6_access_type         = "EXTERNAL"' \
+  'strcontains(self.external_ipv6_prefix, ":")' \
+  'nat_ips                            = [google_compute_address.browser_readiness_ipv6[0].self_link]' \
+  'name                    = google_compute_subnetwork.browser_readiness_ipv6[0].self_link' \
+  'network    = local.browser_readiness_ipv6_network_resource_name' \
+  'subnetwork = local.browser_readiness_ipv6_subnetwork_resource_name' \
+  'google_compute_router_nat.browser_readiness_ipv6'; do
+  require_fixed "$required" terraform/readiness.tf
+done
+require_fixed 'google_compute_subnetwork.browser_readiness_ipv6[0].external_ipv6_prefix' terraform/readiness.tf
+browser_readiness_allowlist="$(sed -n \
+  '/browser_readiness_allowed_ips =/,/] : \[\]/p' terraform/readiness.tf)"
+[ "$(rg -c -F 'google_compute_subnetwork.browser_readiness_ipv6[0].external_ipv6_prefix' \
+  <<<"$browser_readiness_allowlist")" -eq 1 ] ||
+  fail "the preview PPB allowlist must contain exactly the dedicated external IPv6 prefix"
+if rg -q 'google_compute_address' <<<"$browser_readiness_allowlist"; then
+  fail "a browser NAT IPv4 address still grants preview PPB ingress"
+fi
+preview_ipv6_resources="$(sed -n \
+  '/^resource "google_compute_network" "browser_readiness_ipv6"/,/^resource "google_service_account" "backend_readiness"/p' \
+  terraform/readiness.tf)"
+forbid_pattern 'module\.scribe' /dev/stdin <<<"$preview_ipv6_resources"
 require_fixed 'ip_cidr_range = var.browser_readiness_subnet_cidr' terraform/readiness.tf
 require_fixed 'private_ip_google_access = false' terraform/readiness.tf
+[ "$(rg -c -F 'private_ip_google_access = false' terraform/readiness.tf)" -eq 2 ] ||
+  fail "both the legacy and dual-stack browser subnets must keep explicit Private Google Access settings"
 require_fixed 'check "browser_readiness_subnet_isolated"' terraform/readiness.tf
 require_fixed 'setintersection(' terraform/readiness.tf
 [ "$(rg -c -F 'subnetwork = local.readiness_subnetwork_resource_name' terraform/readiness.tf)" -eq 2 ] ||
   fail "only the backend and OCR probes may use the application subnet"
-[ "$(rg -c -F 'subnetwork = local.browser_readiness_subnetwork_resource_name' terraform/readiness.tf)" -eq 1 ] ||
-  fail "only the browser probe may use the NATed browser subnet"
+if rg -Fq 'subnetwork = local.browser_readiness_subnetwork_resource_name' terraform/readiness.tf; then
+  fail "the browser job still attaches to the legacy browser subnet"
+fi
+[ "$(rg -c -F 'subnetwork = local.browser_readiness_ipv6_subnetwork_resource_name' terraform/readiness.tf)" -eq 1 ] ||
+  fail "only the browser probe may use the isolated dual-stack subnet"
 require_fixed 'power_button_allowed_ips = distinct(concat(var.allowed_ips, local.browser_readiness_allowed_ips))' terraform/main.tf
 [ "$(rg -l 'browser_readiness_allowed_ips' terraform/*.tf | wc -l)" -eq 2 ] ||
-  fail "the derived browser /32 must be consumed only by readiness and this preview's PPB allowlist"
+  fail "the derived browser /64 must be consumed only by readiness and this preview's PPB allowlist"
 for iam_file in terraform/backup.tf terraform/iam.tf terraform/kraken.tf terraform/pubsub.tf terraform/storage.tf terraform/vault.tf; do
   [ ! -f "$iam_file" ] || forbid_pattern 'browser_readiness' "$iam_file"
 done

--- a/ci/deploy-local-destroy_test.sh
+++ b/ci/deploy-local-destroy_test.sh
@@ -80,7 +80,7 @@ case "${1:-}" in
   destroy)
     case "${TF_TEST_DESTROY_MODE:-success}" in
       success) ;;
-      fail-once|always-fail|serverless-fail-once|serverless-browser-fail-once|serverless-always-fail|serverless-mixed|serverless-wrong-subnet)
+      fail-once|always-fail|serverless-fail-once|serverless-browser-fail-once|serverless-browser-ipv6-fail-once|serverless-browser-ipv6-wrong-subnet|serverless-always-fail|serverless-mixed|serverless-wrong-subnet)
         attempts=0
         if [ -f "${TF_TEST_DESTROY_ATTEMPTS_FILE}" ]; then
           read -r attempts <"${TF_TEST_DESTROY_ATTEMPTS_FILE}" || true
@@ -99,6 +99,14 @@ case "${1:-}" in
         fi
         if [ "${TF_TEST_DESTROY_MODE}" = "serverless-browser-fail-once" ] && [ "$attempts" -eq 1 ]; then
           echo "Error: Error when reading or editing Subnetwork 'projects/example-project/regions/us-east5/subnetworks/scribe-pr-75-browser-9aac94f3': googleapi: Error 400: already used by 'projects/example-project/regions/us-east5/addresses/serverless-ipv4-scribe-pr-75-browser-9aac94f3', resourceInUseByAnotherResource" >&2
+          exit 1
+        fi
+        if [ "${TF_TEST_DESTROY_MODE}" = "serverless-browser-ipv6-fail-once" ] && [ "$attempts" -eq 1 ]; then
+          echo "Error: Error when reading or editing Subnetwork 'projects/example-project/regions/us-east5/subnetworks/scribe-pr-75-browser-v6-9aac94f3': googleapi: Error 400: already used by 'projects/example-project/regions/us-east5/addresses/serverless-ipv6-scribe-pr-75-browser-v6-9aac94f3', resourceInUseByAnotherResource" >&2
+          exit 1
+        fi
+        if [ "${TF_TEST_DESTROY_MODE}" = "serverless-browser-ipv6-wrong-subnet" ]; then
+          echo "Error: Error when reading or editing Subnetwork 'projects/example-project/regions/us-east5/subnetworks/scribe-pr-76-browser-v6-9aac94f3': googleapi: Error 400: already used by 'projects/example-project/regions/us-east5/addresses/serverless-ipv6-scribe-pr-76-browser-v6-9aac94f3', resourceInUseByAnotherResource" >&2
           exit 1
         fi
         if [ "${TF_TEST_DESTROY_MODE}" = "serverless-wrong-subnet" ]; then
@@ -340,7 +348,7 @@ fi
 [ "$(grep -Fc 'destroy -auto-approve' "${terraform_log}")" -eq 2 ]
 [ "$(grep -Fc 'output -json deployment_inputs' "${terraform_log}")" -eq 1 ]
 grep -Fx 'sleep 300' "${TEST_DIR}/sleep.log" >/dev/null
-grep -F 'waiting for Google to release its serverless-ipv4 subnet reservation' \
+grep -F 'waiting for Google to release its serverless IPv4/IPv6 subnet reservation' \
   "${TEST_DIR}/destroy-serverless-retry.err" >/dev/null
 grep -F 'workspace delete pr-75' "${terraform_log}" >/dev/null
 
@@ -356,8 +364,24 @@ fi
 [ "$(grep -Fc 'destroy -auto-approve' "${terraform_log}")" -eq 2 ]
 [ "$(grep -Fc 'output -json deployment_inputs' "${terraform_log}")" -eq 1 ]
 grep -Fx 'sleep 300' "${TEST_DIR}/sleep.log" >/dev/null
-grep -F 'waiting for Google to release its serverless-ipv4 subnet reservation' \
+grep -F 'waiting for Google to release its serverless IPv4/IPv6 subnet reservation' \
   "${TEST_DIR}/destroy-browser-serverless-retry.err" >/dev/null
+grep -F 'workspace delete pr-75' "${terraform_log}" >/dev/null
+
+# The additive dual-stack network has its own deterministic subnet. Either a
+# provider-managed IPv4 or IPv6 reservation receives the same bounded wait.
+rm -f "${TEST_DIR}/destroy-attempts" "${TEST_DIR}/sleep.log"
+: >"${terraform_log}"
+if ! TF_TEST_DESTROY_MODE=serverless-browser-ipv6-fail-once run_destroy valid \
+  "${TEST_DIR}/destroy-browser-ipv6-serverless-retry.out" "${TEST_DIR}/destroy-browser-ipv6-serverless-retry.err"; then
+  echo "Google-managed dual-stack browser subnet cleanup delay was not retried" >&2
+  exit 1
+fi
+[ "$(grep -Fc 'destroy -auto-approve' "${terraform_log}")" -eq 2 ]
+[ "$(grep -Fc 'output -json deployment_inputs' "${terraform_log}")" -eq 1 ]
+grep -Fx 'sleep 300' "${TEST_DIR}/sleep.log" >/dev/null
+grep -F 'waiting for Google to release its serverless IPv4/IPv6 subnet reservation' \
+  "${TEST_DIR}/destroy-browser-ipv6-serverless-retry.err" >/dev/null
 grep -F 'workspace delete pr-75' "${terraform_log}" >/dev/null
 
 rm -f "${TEST_DIR}/destroy-attempts" "${TEST_DIR}/sleep.log"
@@ -370,14 +394,14 @@ fi
 [ "$(grep -Fc 'destroy -auto-approve' "${terraform_log}")" -eq 25 ]
 [ "$(grep -Fc 'output -json deployment_inputs' "${terraform_log}")" -eq 1 ]
 [ "$(grep -Fxc 'sleep 300' "${TEST_DIR}/sleep.log")" -eq 24 ]
-grep -F 'serverless-ipv4 subnet reservation after 25 bounded attempts over two hours' \
+grep -F 'serverless IPv4/IPv6 subnet reservation after 25 bounded attempts over two hours' \
   "${TEST_DIR}/destroy-serverless-failed.err" >/dev/null
 if grep -F 'workspace delete pr-75' "${terraform_log}" >/dev/null; then
   echo "failed serverless subnet destroy deleted its workspace" >&2
   exit 1
 fi
 
-for destroy_mode in serverless-mixed serverless-wrong-subnet; do
+for destroy_mode in serverless-mixed serverless-wrong-subnet serverless-browser-ipv6-wrong-subnet; do
   rm -f "${TEST_DIR}/destroy-attempts" "${TEST_DIR}/sleep.log"
   : >"${terraform_log}"
   if TF_TEST_DESTROY_MODE="$destroy_mode" run_destroy valid \

--- a/ci/ops-security-contracts.sh
+++ b/ci/ops-security-contracts.sh
@@ -102,12 +102,14 @@ require_pattern 'readiness_network_resource_name = regex\(' terraform/readiness.
 require_pattern 'projects/\[\^/\]\+/global/networks/\[\^/\]\+\$' terraform/readiness.tf
 require_pattern 'readiness_subnetwork_resource_name = regex\(' terraform/readiness.tf
 require_pattern 'projects/\[\^/\]\+/regions/\[\^/\]\+/subnetworks/\[\^/\]\+\$' terraform/readiness.tf
-test "$(rg -c 'network    = local\.readiness_network_resource_name' terraform/readiness.tf)" -eq 3 ||
-  fail "all three readiness jobs must use the canonical Cloud Run network resource name"
+test "$(rg -c 'network    = local\.readiness_network_resource_name' terraform/readiness.tf)" -eq 2 ||
+  fail "backend and OCR readiness must use the canonical application network resource name"
 test "$(rg -c 'subnetwork = local\.readiness_subnetwork_resource_name' terraform/readiness.tf)" -eq 2 ||
   fail "backend and OCR readiness jobs must use the canonical application subnetwork resource name"
-test "$(rg -c 'subnetwork = local\.browser_readiness_subnetwork_resource_name' terraform/readiness.tf)" -eq 1 ||
-  fail "browser readiness must use only its dedicated NATed subnetwork resource name"
+test "$(rg -c 'network    = local\.browser_readiness_ipv6_network_resource_name' terraform/readiness.tf)" -eq 1 ||
+  fail "browser readiness must use only its isolated dual-stack network resource name"
+test "$(rg -c 'subnetwork = local\.browser_readiness_ipv6_subnetwork_resource_name' terraform/readiness.tf)" -eq 1 ||
+  fail "browser readiness must use only its isolated dual-stack subnetwork resource name"
 forbid_pattern 'network    = module\.scribe\.network\.self_link' terraform/readiness.tf
 forbid_pattern 'subnetwork = module\.scribe\.network\.subnetwork' terraform/readiness.tf
 require_pattern 'readiness_jobs = \{' terraform/monitoring.tf

--- a/ci/project-foundation-contract_test.sh
+++ b/ci/project-foundation-contract_test.sh
@@ -11,6 +11,10 @@ fail() {
 }
 
 [ -f terraform/foundation/main.tf ] || fail "standalone foundation root is missing"
+grep -Fq 'terraform -chdir=terraform/foundation init -backend=false -input=false -lockfile=readonly' ci/terraform-check.sh ||
+  fail "the repository Terraform gate does not initialize the singleton foundation"
+grep -Fq 'terraform -chdir=terraform/foundation validate' ci/terraform-check.sh ||
+  fail "the repository Terraform gate does not validate the singleton foundation"
 grep -Eq 'source[[:space:]]*=[[:space:]]*"https://github.com/libops/cloud-compose/archive/[0-9a-f]{40}\.tar\.gz//cloud-compose-[0-9a-f]{40}/modules/gcp-foundation\?archive=tar\.gz"' terraform/foundation/main.tf ||
   fail "foundation does not pin libops/cloud-compose by immutable commit"
 grep -q 'resource "google_artifact_registry_repository" "internal"' terraform/foundation/main.tf ||
@@ -23,6 +27,8 @@ grep -q 'resource "google_project_iam_custom_role" "vault_gcp_auth_key_verifier"
   fail "foundation does not own the Vault verifier role"
 grep -q 'resource "google_project_iam_custom_role" "cloud_compose_observe"' terraform/foundation/main.tf ||
   fail "foundation does not own the production no-suspend role"
+grep -q 'resource "google_project_iam_member" "cloud_run_external_ipv6"' terraform/foundation/main.tf ||
+  fail "foundation does not own the Cloud Run external IPv6 service-agent grant"
 grep -q 'resource "google_project_service" "control_plane"' terraform/foundation/main.tf ||
   fail "foundation does not own its control-plane APIs"
 for service in servicemanagement.googleapis.com serviceusage.googleapis.com; do
@@ -56,6 +62,16 @@ printf '%s\n' "$preview_policy_binding" | grep -Eq 'role[[:space:]]*=[[:space:]]
 # shellcheck disable=SC2016 # Match the literal Terraform interpolation.
 printf '%s\n' "$preview_policy_binding" | grep -Fq 'member     = "serviceAccount:${local.preview_deploy_service_account_email}"' ||
   fail "preview repository-policy role is not bound to the deterministic preview deploy identity"
+
+cloud_run_external_ipv6_binding="$(sed -n '/^resource "google_project_iam_member" "cloud_run_external_ipv6" {/,/^}/p' terraform/foundation/main.tf)"
+printf '%s\n' "$cloud_run_external_ipv6_binding" | grep -Eq 'role[[:space:]]*=[[:space:]]*"roles/compute\.publicIpAdmin"' ||
+  fail "the Cloud Run service agent lacks the required Compute Public IP Admin role"
+printf '%s\n' "$cloud_run_external_ipv6_binding" | grep -Eq 'member[[:space:]]*=[[:space:]]*module\.cloud_compose\.cloud_run_service_agent_member' ||
+  fail "the external IPv6 role is not bound only to the Google-managed Cloud Run service agent"
+printf '%s\n' "$cloud_run_external_ipv6_binding" | grep -Eq 'prevent_destroy[[:space:]]*=[[:space:]]*true' ||
+  fail "the required external IPv6 service-agent grant can be removed with foundation state"
+[ "$(rg -l 'roles/compute\.publicIpAdmin' terraform --glob '*.tf')" = "terraform/foundation/main.tf" ] ||
+  fail "the external IPv6 service-agent role must be singleton foundation state"
 
 foundation_state="$(sed -n '/^data "terraform_remote_state" "shared_foundation" {/,/^}/p' terraform/main.tf)"
 printf '%s\n' "$foundation_state" | grep -Eq 'prefix[[:space:]]*=[[:space:]]*local\.foundation_state_prefix' ||

--- a/ci/terraform-check.sh
+++ b/ci/terraform-check.sh
@@ -12,10 +12,12 @@ TERRAFORM_IMAGE="${TERRAFORM_IMAGE:-hashicorp/terraform:1.15.8@sha256:7ae513256f
 run_checks() {
   terraform fmt -check -recursive terraform
   terraform -chdir=terraform init -backend=false -input=false -lockfile=readonly
+  terraform -chdir=terraform/foundation init -backend=false -input=false -lockfile=readonly
   sh ci/cloud-compose-snapshot-contract_test.sh
   sh ci/cloud-compose-release-contract_test.sh
   sh ci/terraform-moved-refresh_test.sh
   terraform -chdir=terraform validate
+  terraform -chdir=terraform/foundation validate
 }
 
 if command -v terraform >/dev/null 2>&1; then
@@ -32,7 +34,7 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 127
 fi
 
-check_command='terraform fmt -check -recursive terraform && terraform -chdir=terraform init -backend=false -input=false -lockfile=readonly && sh ci/cloud-compose-snapshot-contract_test.sh && sh ci/cloud-compose-release-contract_test.sh && sh ci/terraform-moved-refresh_test.sh && terraform -chdir=terraform validate'
+check_command='terraform fmt -check -recursive terraform && terraform -chdir=terraform init -backend=false -input=false -lockfile=readonly && terraform -chdir=terraform/foundation init -backend=false -input=false -lockfile=readonly && sh ci/cloud-compose-snapshot-contract_test.sh && sh ci/cloud-compose-release-contract_test.sh && sh ci/terraform-moved-refresh_test.sh && terraform -chdir=terraform validate && terraform -chdir=terraform/foundation validate'
 container_id="$(
   docker create \
     --workdir /repo \
@@ -55,6 +57,7 @@ tar \
   --exclude=secrets \
   --exclude=site \
   --exclude=terraform/.terraform \
+  --exclude=terraform/foundation/.terraform \
   --exclude='web/node_modules*' \
   --exclude=web/dist \
   --exclude='mirador-scribe/node_modules*' \

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -118,8 +118,23 @@ staged PR-head fixture. The source SHA tags the image and Terraform records its
 resolved digest. The script runs only after the preview apply in a no-IAM,
 preview-only Playwright job with digest-pinned runtime and browser dependencies.
 Its dedicated service account has no project, storage, Vault, Pub/Sub, or OCR
-IAM grants. A browser-only `/26` and NAT can reach only the canonical
-`scribe-pr-*` Cloud Run origin; production and other previews are not widened.
+IAM grants. An independent browser-only VPC gives its dual-stack `/26` one
+external IPv6 `/64`; that dedicated `/64` is the sole browser range added to
+the preview's PPB policy. The singleton project foundation grants
+`roles/compute.publicIpAdmin` only to Google's Cloud Run service agent, as
+required for external-IPv6 Direct VPC addresses; no preview workspace or
+application identity owns that project-wide grant. Cloud NAT exists only for
+fixed public DNS and reviewed IPv4-only fixture origins. The exact-head runner
+must force the canonical `scribe-pr-*` host over AAAA and fail closed if it
+cannot, because Public Cloud NAT does not translate
+`run.app` traffic. A protected helper retries fixed public AAAA resolution for
+at most two minutes, accepts at most 32 public-global answers, selects one
+deterministic address for Chromium's exact-host resolver rule, and disables
+Node's IPv4 family race for Playwright API requests. Production and other
+previews are not widened. The former
+application-VPC browser subnet and NAT remain state-managed during the
+additive migration, but the job is detached from them and their `/32` is no
+longer allowlisted.
 
 The scenario uses preview-anonymous auth and leaves the upload selector on
 resolver-backed `Default` (`0`), then verifies the resulting durable

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -132,18 +132,20 @@ recovery is required. The workspace is deleted only after a successful destroy.
 
 A preview that uses Cloud Run Direct VPC can fail after its services are gone
 with `resourceInUseByAnotherResource` and an
-`/addresses/serverless-ipv4-...` reservation still holding the preview subnet.
+`/addresses/serverless-ipv4-...` or `/addresses/serverless-ipv6-...`
+reservation still holding the preview subnet.
 This is a Google-managed cleanup delay, not permission to edit Terraform state
 or delete the reservation: Google documents a **one-to-two-hour wait** after
 removing the Cloud Run resources before deleting the subnet. When Terraform's
-preview-destroy diagnostic contains both the managed `serverless-ipv4-*`
-address and `resourceInUseByAnotherResource`, the protected job retries every
-five minutes for up to two hours using the same already-validated deployment
-inputs. Every Terraform error in that attempt must identify either the exact
-current preview application subnet or its exact deterministic browser subnet,
-plus a managed address; mixed or differently scoped failures retain the
-ordinary bound. The wait retains the shared preview serialization lock and the
-job-scoped deploy identity so no other preview can replace shared runtime
+preview-destroy diagnostic contains either exact managed `serverless-ipv4-*`
+or `serverless-ipv6-*` address and `resourceInUseByAnotherResource`, the
+protected job retries every five minutes for up to two hours using the same
+already-validated deployment inputs. Every Terraform error in that attempt
+must identify either the exact current preview application subnet, its exact
+deterministic legacy browser subnet, or its exact deterministic dual-stack
+browser subnet, plus a managed address; mixed or differently scoped failures
+retain the ordinary bound. The wait retains the shared preview serialization
+lock and the job-scoped deploy identity so no other preview can replace shared runtime
 bindings during a partial teardown. Its preview-only timeout leaves a one-hour
 execution and cleanup margin beyond the two-hour sleep budget; other deploy
 modes retain their shorter timeout. After Terraform succeeds, the workflow
@@ -154,7 +156,8 @@ released the address after the longer bound, let the run fail closed and rerun
 **Terraform Preview** from protected `main` later. Use ordinary `destroy` while
 the current state still has a readable `deployment_inputs` output. If ordinary
 destroy instead reports that the output is absent, use `recover-destroy` as
-described below. Never manually delete a `serverless-ipv4-*` reservation. See
+described below. Never manually delete a `serverless-ipv4-*` or
+`serverless-ipv6-*` reservation. See
 Google's
 [Direct VPC subnet deletion guidance](https://cloud.google.com/run/docs/configuring/vpc-direct-vpc#ip-address-allocation).
 
@@ -467,10 +470,25 @@ runtime and browser are digest-pinned, run as `pwuser`, and receive only the
 preview's canonical HTTPS origin. A dedicated Cloud Run job uses a dedicated
 service account with no project, storage, Vault, Pub/Sub, or OCR IAM grants.
 Direct VPC egress attaches only this job to a dedicated, non-overlapping preview
-`/26`; Cloud NAT covers only that subnet and a reserved regional address. The
-VM, backend probe, OCR probe, and application subnet cannot use that NAT path.
-Terraform derives one `/32` from the address and appends it only to that
-preview's PPB ingress allowlist. Production and other previews are not widened.
+`/26` in an independent custom VPC. The subnet is dual stack and receives one
+external IPv6 `/64`; Terraform appends only that dedicated `/64` to this
+preview's PPB ingress allowlist. The standalone project foundation owns the
+documented `roles/compute.publicIpAdmin` grant for Google's Cloud Run service
+agent. It is never recreated by a preview workspace, and no human, deploy, or
+application identity receives that role. Cloud NAT and a reserved regional
+IPv4 address cover the same subnet only for fixed public DNS and reviewed
+IPv4-only fixture origins. Public Cloud NAT automatically uses Private Google
+Access rather than translating
+`run.app`, so the exact-head runner must force the canonical preview host over
+AAAA and fail closed if that path is unavailable. The protected routing helper
+accepts at most 32 public-global AAAA answers, maps only the exact canonical
+host in Chromium, and disables Node's IPv4 family race for Playwright API
+requests. The VM, backend probe, OCR
+probe, application subnet, production, and other previews cannot use the
+dedicated `/64`. The original application-VPC browser subnet, address, router,
+and NAT stay state-managed during this additive migration to avoid blocking an
+apply on delayed Direct VPC address release; the job is detached from that
+subnet and its former `/32` is no longer allowlisted.
 
 The job authenticates through the existing isolated
 `AUTH_PREVIEW_ANONYMOUS` workspace. It leaves context selection on `Default`
@@ -641,7 +659,11 @@ Management with `disable_on_destroy = false` and
 `deletion_policy = "ABANDON"`, so removing them from state leaves both APIs
 enabled. The manual plan path does not perform that bootstrap or any other API
 mutation. Dev, production, and previews only consume the foundation outputs.
-The foundation also grants the protected preview deploy identity a custom role
+The foundation also owns the one project-wide
+`roles/compute.publicIpAdmin` binding that Google requires for its managed
+Cloud Run service agent to use external-IPv6 Direct VPC subnets. Application
+workspaces do not manage that singleton binding. The foundation also grants
+the protected preview deploy identity a custom role
 containing only `artifactregistry.repositories.getIamPolicy` and
 `artifactregistry.repositories.setIamPolicy`, and binds it only on the
 reviewed `us/internal` repository. The built-in repository administrator role

--- a/docs/reference/quality-gates.md
+++ b/docs/reference/quality-gates.md
@@ -189,9 +189,20 @@ production default Ollama OCR request. Fixture contracts require authenticated
 requests, real image bytes, JPEG validation, non-empty model output, and Ollama
 `done=true`; a health-only response is not deployment evidence.
 
-Preview readiness also runs a digest-pinned Playwright image on a dedicated
-non-overlapping `/26`; Cloud NAT covers only that browser subnet, and its static
-address is the sole additional PPB `/32`. Trusted orchestration fetches only the
+Preview readiness also runs a digest-pinned Playwright image in an independent
+custom VPC. Its non-overlapping dual-stack `/26` receives one external IPv6
+`/64`, and only that environment-owned `/64` is added to the preview PPB
+policy. A static Cloud NAT address remains available only for fixed public DNS
+and reviewed IPv4-only fixture origins; `run.app` is forced over AAAA because
+Public Cloud NAT does not translate Google service traffic. A protected,
+unit-tested helper bounds and validates public-global AAAA answers, supplies
+Chromium's exact-host
+mapping, and disables Node IPv4 racing for Playwright API requests. The
+singleton foundation binds Google's required `roles/compute.publicIpAdmin`
+only to the managed Cloud Run service agent, never to preview state or an
+application identity. The detached legacy browser subnet and NAT remain
+state-managed during the additive migration but grant no PPB access. Trusted
+orchestration fetches only the
 readiness script at the exact resolved same-repository PR-head SHA before cloud
 authentication, walks its exact commit tree, requires unique tree parents and a
 `100644` source blob, and reconciles the bounded Contents payload with that blob

--- a/mirador-scribe/package-lock.json
+++ b/mirador-scribe/package-lock.json
@@ -2477,9 +2477,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -3211,9 +3211,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -62,8 +62,11 @@ the missing image reference.
 | Preview | `pr-<number>` | `scribe-pr-<number>` | immutable protected base SHA | consumes dev Vault and production Ollama state |
 
 Application workspaces read singleton foundation state and never recreate its
-resources. Initialize that state with the default workspace and isolated
-prefix:
+resources. That foundation also binds Google's managed Cloud Run service agent
+to `roles/compute.publicIpAdmin`, which external-IPv6 Direct VPC subnets
+require; per-preview states and application identities never own that
+project-wide grant. Initialize the foundation state with the default workspace
+and isolated prefix:
 
 The protected foundation apply enables `serviceusage.googleapis.com` after
 verifying the production WIF boundary and before Terraform initialization.
@@ -144,10 +147,11 @@ image resolution, pull, or build tooling; remote-state, provider, backup-policy,
 and Vault authentication prerequisites may still be required. Refresh and
 ordinary destroy require an existing selected workspace and never create one.
 Destroy retains its one validated input snapshot across at most three attempts
-for ordinary failures. A Google-managed `serverless-ipv4-*` dependency on
-either the exact preview application subnet or the exact deterministic browser
-subnet receives up to 25 attempts, five minutes apart, because Cloud Run Direct
-VPC address release can take two hours; it does not authorize deletion of the
+for ordinary failures. A Google-managed `serverless-ipv4-*` or
+`serverless-ipv6-*` dependency on the exact preview application subnet, exact
+legacy browser subnet, or exact independent dual-stack browser subnet receives
+up to 25 attempts, five minutes apart, because Cloud Run Direct VPC address
+release can take two hours; it does not authorize deletion of the
 provider-managed address. Only preview destroy
 receives the extended workflow timeout; other deployment modes keep the
 ordinary bound. A preview workspace is deleted only after destroy succeeds. If

--- a/terraform/deploy-local.sh
+++ b/terraform/deploy-local.sh
@@ -917,11 +917,15 @@ if [[ ! "$data_generation" =~ ^canonical-v(1|2)$ ]]; then
 fi
 
 browser_readiness_subnet_name=""
+browser_readiness_ipv6_subnet_name=""
 if [ "$environment" = "preview" ] && [[ "$browser_readiness_image" =~ [^[:space:]] ]]; then
   browser_readiness_name_hash="$(sha256_text "${TF_VAR_name}:${target_workspace}")"
   browser_readiness_name_prefix="${TF_VAR_name:0:46}"
   browser_readiness_name_prefix="${browser_readiness_name_prefix%-}"
   browser_readiness_subnet_name="${browser_readiness_name_prefix}-browser-${browser_readiness_name_hash:0:8}"
+  browser_readiness_ipv6_name_prefix="${TF_VAR_name:0:43}"
+  browser_readiness_ipv6_name_prefix="${browser_readiness_ipv6_name_prefix%-}"
+  browser_readiness_ipv6_subnet_name="${browser_readiness_ipv6_name_prefix}-browser-v6-${browser_readiness_name_hash:0:8}"
 fi
 
 if [ -n "$dev_external_ocr_impersonators" ]; then
@@ -1076,11 +1080,19 @@ case "$action" in
           serverless_error_seen=true
           app_subnet_marker="/subnetworks/${TF_VAR_name}'"
           browser_subnet_marker="/subnetworks/${browser_readiness_subnet_name}'"
+          browser_ipv6_subnet_marker="/subnetworks/${browser_readiness_ipv6_subnet_name}'"
+          known_serverless_subnet=false
+          if [[ "$destroy_diagnostic_line" == *"$app_subnet_marker"* ]] \
+            || { [ -n "$browser_readiness_subnet_name" ] \
+              && [[ "$destroy_diagnostic_line" == *"$browser_subnet_marker"* ]]; } \
+            || { [ -n "$browser_readiness_ipv6_subnet_name" ] \
+              && [[ "$destroy_diagnostic_line" == *"$browser_ipv6_subnet_marker"* ]]; }; then
+            known_serverless_subnet=true
+          fi
           if [[ "$destroy_diagnostic_line" != *resourceInUseByAnotherResource* ]] \
-            || { [[ "$destroy_diagnostic_line" != *"$app_subnet_marker"* ]] \
-              && { [ -z "$browser_readiness_subnet_name" ] \
-                || [[ "$destroy_diagnostic_line" != *"$browser_subnet_marker"* ]]; }; } \
-            || [[ "$destroy_diagnostic_line" != *'/addresses/serverless-ipv4-'* ]]; then
+            || [ "$known_serverless_subnet" != "true" ] \
+            || { [[ "$destroy_diagnostic_line" != *'/addresses/serverless-ipv4-'* ]] \
+              && [[ "$destroy_diagnostic_line" != *'/addresses/serverless-ipv6-'* ]]; }; then
             serverless_subnet_delay=false
             break
           fi
@@ -1091,10 +1103,10 @@ case "$action" in
       fi
       if [ "$serverless_subnet_delay" = "true" ]; then
         if [ "$destroy_attempt" -ge "$serverless_destroy_attempt_limit" ]; then
-          echo "Terraform preview destroy still has a Google-managed serverless-ipv4 subnet reservation after ${serverless_destroy_attempt_limit} bounded attempts over two hours; leaving the workspace in place for operator recovery." >&2
+          echo "Terraform preview destroy still has a Google-managed serverless IPv4/IPv6 subnet reservation after ${serverless_destroy_attempt_limit} bounded attempts over two hours; leaving the workspace in place for operator recovery." >&2
           exit 1
         fi
-        echo "Terraform preview destroy attempt ${destroy_attempt}/${serverless_destroy_attempt_limit} is waiting for Google to release its serverless-ipv4 subnet reservation; retrying in ${serverless_retry_delay_seconds}s with the same state-derived inputs." >&2
+        echo "Terraform preview destroy attempt ${destroy_attempt}/${serverless_destroy_attempt_limit} is waiting for Google to release its serverless IPv4/IPv6 subnet reservation; retrying in ${serverless_retry_delay_seconds}s with the same state-derived inputs." >&2
         sleep "$serverless_retry_delay_seconds"
       else
         if [ "$destroy_attempt" -ge "$destroy_attempt_limit" ]; then

--- a/terraform/foundation/main.tf
+++ b/terraform/foundation/main.tf
@@ -40,6 +40,20 @@ module "cloud_compose" {
   depends_on = [google_project_service.control_plane]
 }
 
+# Cloud Run's ordinary service-agent role covers Direct VPC egress, but Google
+# requires this additional role when the selected subnet uses external IPv6.
+# Own the project-wide grant once in foundation state; preview workspaces must
+# never race each other by managing the same IAM member independently.
+resource "google_project_iam_member" "cloud_run_external_ipv6" {
+  project = var.project_id
+  role    = "roles/compute.publicIpAdmin"
+  member  = module.cloud_compose.cloud_run_service_agent_member
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
 resource "google_project_service" "artifact_registry" {
   project            = var.project_id
   service            = "artifactregistry.googleapis.com"

--- a/terraform/readiness.tf
+++ b/terraform/readiness.tf
@@ -17,15 +17,22 @@ locals {
   )
   normalized_browser_readiness_image = trimspace(var.browser_readiness_image)
   browser_readiness_enabled          = local.is_preview_workspace && local.normalized_browser_readiness_image != ""
-  browser_readiness_subnetwork_resource_name = try(regex(
-    "projects/[^/]+/regions/[^/]+/subnetworks/[^/]+$",
-    google_compute_subnetwork.browser_readiness[0].self_link,
+  browser_readiness_ipv6_network_resource_name = try(regex(
+    "projects/[^/]+/global/networks/[^/]+$",
+    google_compute_network.browser_readiness_ipv6[0].self_link,
   ), "")
-  browser_readiness_name_hash     = substr(sha256("${var.name}:${local.workspace_slug}"), 0, 8)
-  browser_readiness_resource_name = "${trimsuffix(substr(var.name, 0, 46), "-")}-browser-${local.browser_readiness_name_hash}"
-  browser_readiness_job_name      = "${trimsuffix(substr(var.name, 0, 32), "-")}-browser-${local.browser_readiness_name_hash}"
-  browser_readiness_account_id    = "${trimsuffix(substr("probe-browser-${local.workspace_slug}", 0, 21), "-")}-${local.browser_readiness_name_hash}"
-  browser_readiness_allowed_ips   = local.browser_readiness_enabled ? ["${google_compute_address.browser_readiness[0].address}/32"] : []
+  browser_readiness_ipv6_subnetwork_resource_name = try(regex(
+    "projects/[^/]+/regions/[^/]+/subnetworks/[^/]+$",
+    google_compute_subnetwork.browser_readiness_ipv6[0].self_link,
+  ), "")
+  browser_readiness_name_hash          = substr(sha256("${var.name}:${local.workspace_slug}"), 0, 8)
+  browser_readiness_resource_name      = "${trimsuffix(substr(var.name, 0, 46), "-")}-browser-${local.browser_readiness_name_hash}"
+  browser_readiness_ipv6_resource_name = "${trimsuffix(substr(var.name, 0, 43), "-")}-browser-v6-${local.browser_readiness_name_hash}"
+  browser_readiness_job_name           = "${trimsuffix(substr(var.name, 0, 32), "-")}-browser-${local.browser_readiness_name_hash}"
+  browser_readiness_account_id         = "${trimsuffix(substr("probe-browser-${local.workspace_slug}", 0, 21), "-")}-${local.browser_readiness_name_hash}"
+  browser_readiness_allowed_ips = local.browser_readiness_enabled ? [
+    google_compute_subnetwork.browser_readiness_ipv6[0].external_ipv6_prefix,
+  ] : []
 }
 
 # Direct VPC egress requires at least a /26. Keep the browser runner outside the
@@ -52,14 +59,14 @@ resource "google_compute_subnetwork" "browser_readiness" {
   name          = local.browser_readiness_resource_name
   network       = module.scribe.network.self_link
   ip_cidr_range = var.browser_readiness_subnet_cidr
-  # Default run.app traffic must take the public route through the static NAT;
-  # Private Google Access can report a non-NAT source for Google API domains.
+  # Retained unchanged until previews created before the external-IPv6
+  # migration have been destroyed. The browser job no longer attaches here.
   private_ip_google_access = false
 }
 
-# The public PPB service is source-IP restricted. Give the preview-only browser
-# job one stable egress address, then add only that derived /32 to this
-# preview's PPB allowlist. No shared or production ingress policy is widened.
+# Retain the original address/router/NAT resource addresses during the additive
+# migration so applying the prerequisite never waits for a detached Direct VPC
+# subnet to become deletable. This /32 is no longer in the preview PPB policy.
 resource "google_compute_address" "browser_readiness" {
   count = local.browser_readiness_enabled ? 1 : 0
 
@@ -92,6 +99,87 @@ resource "google_compute_router_nat" "browser_readiness" {
 
   subnetwork {
     name                    = google_compute_subnetwork.browser_readiness[0].self_link
+    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  }
+}
+
+# Public Cloud NAT does not translate traffic to run.app: it automatically
+# enables Private Google Access for covered IPv4 ranges, and Cloud Run can then
+# observe 0.0.0.0 instead of the reserved NAT address. Keep the legacy preview
+# resources above state-addressable during this additive migration, but run the
+# browser in its own dual-stack VPC. The dedicated external /64 is stable for
+# the subnet lifetime and is the only browser range added to this preview's PPB
+# policy. No application, shared, or production subnet can use that range.
+resource "google_compute_network" "browser_readiness_ipv6" {
+  count = local.browser_readiness_enabled ? 1 : 0
+
+  project                 = var.project_id
+  name                    = local.browser_readiness_ipv6_resource_name
+  auto_create_subnetworks = false
+  routing_mode            = "REGIONAL"
+  mtu                     = 1460
+}
+
+resource "google_compute_subnetwork" "browser_readiness_ipv6" {
+  count = local.browser_readiness_enabled ? 1 : 0
+
+  project                  = var.project_id
+  region                   = var.region
+  name                     = local.browser_readiness_ipv6_resource_name
+  network                  = google_compute_network.browser_readiness_ipv6[0].self_link
+  ip_cidr_range            = var.browser_readiness_subnet_cidr
+  stack_type               = "IPV4_IPV6"
+  ipv6_access_type         = "EXTERNAL"
+  private_ip_google_access = false
+
+  lifecycle {
+    postcondition {
+      condition = (
+        can(cidrhost(self.external_ipv6_prefix, 0)) &&
+        strcontains(self.external_ipv6_prefix, ":") &&
+        endswith(self.external_ipv6_prefix, "/64")
+      )
+      error_message = "The preview browser readiness subnet must receive one canonical external IPv6 /64."
+    }
+  }
+}
+
+# The browser still needs IPv4 egress for fixed public DNS and reviewed
+# cross-origin fixtures that do not publish AAAA records. This NAT is not an
+# ingress credential: canonical Scribe traffic is explicitly forced over IPv6
+# by the PR-head runner.
+resource "google_compute_address" "browser_readiness_ipv6" {
+  count = local.browser_readiness_enabled ? 1 : 0
+
+  project      = var.project_id
+  region       = var.region
+  name         = local.browser_readiness_ipv6_resource_name
+  address_type = "EXTERNAL"
+  network_tier = "PREMIUM"
+}
+
+resource "google_compute_router" "browser_readiness_ipv6" {
+  count = local.browser_readiness_enabled ? 1 : 0
+
+  project = var.project_id
+  region  = var.region
+  name    = local.browser_readiness_ipv6_resource_name
+  network = google_compute_network.browser_readiness_ipv6[0].self_link
+}
+
+resource "google_compute_router_nat" "browser_readiness_ipv6" {
+  count = local.browser_readiness_enabled ? 1 : 0
+
+  project                            = var.project_id
+  region                             = var.region
+  name                               = local.browser_readiness_ipv6_resource_name
+  router                             = google_compute_router.browser_readiness_ipv6[0].name
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            = [google_compute_address.browser_readiness_ipv6[0].self_link]
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+
+  subnetwork {
+    name                    = google_compute_subnetwork.browser_readiness_ipv6[0].self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 }
@@ -165,13 +253,21 @@ resource "google_cloud_run_v2_job" "browser_readiness" {
           name  = "SCRIBE_BROWSER_BASE_URL"
           value = local.public_base_url
         }
+
+        # Playwright's APIRequestContext uses Node networking rather than the
+        # Chromium resolver rule. Put AAAA first and disable IPv4 racing so all
+        # canonical API requests use the same PPB-authorized IPv6 path.
+        env {
+          name  = "NODE_OPTIONS"
+          value = "--dns-result-order=ipv6first --no-network-family-autoselection"
+        }
       }
 
       vpc_access {
         egress = "ALL_TRAFFIC"
         network_interfaces {
-          network    = local.readiness_network_resource_name
-          subnetwork = local.browser_readiness_subnetwork_resource_name
+          network    = local.browser_readiness_ipv6_network_resource_name
+          subnetwork = local.browser_readiness_ipv6_subnetwork_resource_name
         }
       }
     }
@@ -179,6 +275,7 @@ resource "google_cloud_run_v2_job" "browser_readiness" {
 
   depends_on = [
     google_compute_router_nat.browser_readiness,
+    google_compute_router_nat.browser_readiness_ipv6,
     google_service_account.browser_readiness,
     module.scribe,
   ]

--- a/web/e2e/deployed-readiness-routing.mjs
+++ b/web/e2e/deployed-readiness-routing.mjs
@@ -1,0 +1,127 @@
+import { setDefaultResultOrder } from "node:dns";
+import { Resolver } from "node:dns/promises";
+import { isIP, setDefaultAutoSelectFamily } from "node:net";
+
+const canonicalScribeRunAppHostnamePattern = /^scribe(?:-pr-[1-9][0-9]*)?-[1-9][0-9]*\.[a-z]+-[a-z]+[0-9]+\.run\.app$/;
+const maximumIPv6Answers = 32;
+const defaultResolutionTimeoutMs = 120_000;
+const maximumResolutionTimeoutMs = 180_000;
+const defaultResolutionAttemptTimeoutMs = 10_000;
+const defaultResolutionRetryIntervalMs = 2_000;
+const publicDNSResolvers = Object.freeze(["8.8.8.8", "8.8.4.4"]);
+
+function canonicalScribeHostname(hostname) {
+  const normalized = String(hostname ?? "").trim().toLowerCase();
+  if (!canonicalScribeRunAppHostnamePattern.test(normalized)) {
+    throw new Error("invalid canonical Scribe host");
+  }
+  return normalized;
+}
+
+function globalUnicastIPv6(address) {
+  const normalized = String(address ?? "").trim().toLowerCase();
+  if (isIP(normalized) !== 6) return "";
+  const firstHextet = Number.parseInt(normalized.split(":", 1)[0], 16);
+  // IANA's current global-unicast allocation is 2000::/3. Restrict the
+  // browser mapping to that public range so a malformed DNS response cannot
+  // redirect the canonical origin to loopback, link-local, ULA, or multicast.
+  if (
+    !Number.isInteger(firstHextet)
+    || firstHextet < 0x2000
+    || firstHextet > 0x3fff
+  ) return "";
+  return normalized;
+}
+
+export function selectCanonicalGlobalIPv6(records) {
+  if (!Array.isArray(records) || records.length === 0 || records.length > maximumIPv6Answers) {
+    throw new Error("canonical IPv6 resolution failed");
+  }
+  const candidates = [...new Set(records.map(globalUnicastIPv6).filter(Boolean))].sort();
+  if (candidates.length === 0) throw new Error("canonical IPv6 resolution failed");
+  return candidates[0];
+}
+
+export function chromiumIPv6HostResolverArgument(hostname, address) {
+  const canonicalHostname = canonicalScribeHostname(hostname);
+  const canonicalAddress = globalUnicastIPv6(address);
+  if (!canonicalAddress) throw new Error("invalid canonical IPv6 address");
+  return `--host-resolver-rules=MAP ${canonicalHostname} [${canonicalAddress}]`;
+}
+
+export async function configureCanonicalIPv6Routing(hostname, options = {}) {
+  const canonicalHostname = canonicalScribeHostname(hostname);
+  const timeoutMs = options.timeoutMs ?? defaultResolutionTimeoutMs;
+  const attemptTimeoutMs = options.attemptTimeoutMs ?? defaultResolutionAttemptTimeoutMs;
+  const retryIntervalMs = options.retryIntervalMs ?? defaultResolutionRetryIntervalMs;
+  if (
+    !Number.isSafeInteger(timeoutMs)
+    || timeoutMs < 1
+    || timeoutMs > maximumResolutionTimeoutMs
+    || !Number.isSafeInteger(attemptTimeoutMs)
+    || attemptTimeoutMs < 1
+    || attemptTimeoutMs > maximumResolutionTimeoutMs
+    || !Number.isSafeInteger(retryIntervalMs)
+    || retryIntervalMs < 0
+    || retryIntervalMs > maximumResolutionTimeoutMs
+  ) {
+    throw new Error("invalid canonical IPv6 resolution timeout");
+  }
+
+  const resolverFactory = options.resolverFactory ?? (() => new Resolver());
+  const deadline = Date.now() + timeoutMs;
+  let address = "";
+  while (Date.now() < deadline) {
+    const resolver = resolverFactory();
+    if (
+      typeof resolver?.resolve6 !== "function"
+      || typeof resolver?.cancel !== "function"
+      || typeof resolver?.setServers !== "function"
+    ) {
+      throw new Error("canonical IPv6 resolver unavailable");
+    }
+
+    let attemptTimer;
+    try {
+      // The container resolver may suppress AAAA on an IPv4-first host even
+      // though the Direct VPC subnet is dual stack. Use fixed validating Google
+      // Public DNS resolvers so canonical routing never depends on that heuristic.
+      resolver.setServers([...publicDNSResolvers]);
+      const remainingMs = Math.max(1, deadline - Date.now());
+      const records = await Promise.race([
+        Promise.resolve().then(() => resolver.resolve6(canonicalHostname)),
+        new Promise((_, reject) => {
+          attemptTimer = setTimeout(() => {
+            try {
+              resolver.cancel();
+            } catch {
+              // Cancellation is best-effort; the total deadline remains
+              // authoritative and no raw resolver error is emitted.
+            }
+            reject(new Error("canonical IPv6 resolution attempt timed out"));
+          }, Math.min(attemptTimeoutMs, remainingMs));
+        }),
+      ]);
+      address = selectCanonicalGlobalIPv6(records);
+      break;
+    } catch {
+      // Direct VPC and Cloud NAT can both be cold when a new task starts.
+      // Retry only this fixed DNS query until one absolute bounded deadline.
+    } finally {
+      clearTimeout(attemptTimer);
+    }
+
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) break;
+    await new Promise((resolve) => {
+      setTimeout(resolve, Math.min(retryIntervalMs, remainingMs));
+    });
+  }
+  if (!address) throw new Error("canonical IPv6 resolution timed out");
+
+  const setResultOrder = options.setResultOrder ?? setDefaultResultOrder;
+  const setAutoSelectFamily = options.setAutoSelectFamily ?? setDefaultAutoSelectFamily;
+  setResultOrder("ipv6first");
+  setAutoSelectFamily(false);
+  return chromiumIPv6HostResolverArgument(canonicalHostname, address);
+}

--- a/web/e2e/deployed-readiness-routing_test.mjs
+++ b/web/e2e/deployed-readiness-routing_test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  chromiumIPv6HostResolverArgument,
+  configureCanonicalIPv6Routing,
+  selectCanonicalGlobalIPv6,
+} from "./deployed-readiness-routing.mjs";
+
+test("selectCanonicalGlobalIPv6 accepts only a bounded global-unicast answer", () => {
+  assert.equal(
+    selectCanonicalGlobalIPv6([
+      "2a00:1450:4001:82b::2004",
+      "2607:f8b0:4004:c1b::65",
+      "2A00:1450:4001:82B::2004",
+    ]),
+    "2607:f8b0:4004:c1b::65",
+  );
+  for (const records of [
+    [],
+    ["192.0.2.10"],
+    ["::1"],
+    ["fe80::1"],
+    ["fd00::1"],
+    ["ff02::1"],
+    Array.from({ length: 33 }, (_, index) => `2607:f8b0:4004:c1b::${index + 1}`),
+  ]) {
+    assert.throws(
+      () => selectCanonicalGlobalIPv6(records),
+      /canonical IPv6 resolution failed/,
+    );
+  }
+});
+
+test("chromium resolver rule maps only a canonical Scribe run.app host", () => {
+  assert.equal(
+    chromiumIPv6HostResolverArgument(
+      "scribe-pr-99-915966395449.us-east5.run.app",
+      "2607:f8b0:4004:c1b::65",
+    ),
+    "--host-resolver-rules=MAP scribe-pr-99-915966395449.us-east5.run.app [2607:f8b0:4004:c1b::65]",
+  );
+  assert.equal(
+    chromiumIPv6HostResolverArgument(
+      "scribe-915966395449.us-east5.run.app",
+      "2607:f8b0:4004:c1b::65",
+    ),
+    "--host-resolver-rules=MAP scribe-915966395449.us-east5.run.app [2607:f8b0:4004:c1b::65]",
+  );
+  assert.throws(
+    () => chromiumIPv6HostResolverArgument("other.example", "2607:f8b0:4004:c1b::65"),
+    /invalid canonical Scribe host/,
+  );
+  assert.throws(
+    () => chromiumIPv6HostResolverArgument(
+      "scribe-pr-99-915966395449.us-east5.run.app",
+      "127.0.0.1",
+    ),
+    /invalid canonical IPv6 address/,
+  );
+});
+
+test("configureCanonicalIPv6Routing fences Node fallback and returns one Chromium map", async () => {
+  const calls = [];
+  const resolver = {
+    cancel() {
+      calls.push("cancel");
+    },
+    setServers(servers) {
+      calls.push(["servers", servers]);
+    },
+    async resolve6(hostname) {
+      calls.push(["resolve6", hostname]);
+      return ["2a00:1450:4001:82b::2004"];
+    },
+  };
+  const chromiumArgument = await configureCanonicalIPv6Routing(
+    "scribe-pr-99-915966395449.us-east5.run.app",
+    {
+      resolverFactory: () => resolver,
+      setAutoSelectFamily: (value) => calls.push(["auto", value]),
+      setResultOrder: (value) => calls.push(["order", value]),
+      timeoutMs: 100,
+    },
+  );
+  assert.equal(
+    chromiumArgument,
+    "--host-resolver-rules=MAP scribe-pr-99-915966395449.us-east5.run.app [2a00:1450:4001:82b::2004]",
+  );
+  assert.deepEqual(calls, [
+    ["servers", ["8.8.8.8", "8.8.4.4"]],
+    ["resolve6", "scribe-pr-99-915966395449.us-east5.run.app"],
+    ["order", "ipv6first"],
+    ["auto", false],
+  ]);
+});
+
+test("configureCanonicalIPv6Routing cancels a bounded unresolved query", async () => {
+  let cancelled = false;
+  const resolver = {
+    cancel() {
+      cancelled = true;
+    },
+    setServers() {},
+    async resolve6() {
+      return new Promise(() => {});
+    },
+  };
+  await assert.rejects(
+    configureCanonicalIPv6Routing("scribe-915966395449.us-east5.run.app", {
+      resolverFactory: () => resolver,
+      timeoutMs: 5,
+    }),
+    /canonical IPv6 resolution timed out/,
+  );
+  assert.equal(cancelled, true);
+});
+
+test("configureCanonicalIPv6Routing retries a transient fixed-DNS failure", async () => {
+  let attempts = 0;
+  const chromiumArgument = await configureCanonicalIPv6Routing(
+    "scribe-pr-99-915966395449.us-east5.run.app",
+    {
+      attemptTimeoutMs: 20,
+      resolverFactory: () => ({
+        cancel() {},
+        setServers() {},
+        async resolve6() {
+          attempts += 1;
+          if (attempts === 1) throw new Error("transient network failure");
+          return ["2607:f8b0:4004:c1b::65"];
+        },
+      }),
+      retryIntervalMs: 1,
+      setAutoSelectFamily() {},
+      setResultOrder() {},
+      timeoutMs: 100,
+    },
+  );
+  assert.equal(attempts, 2);
+  assert.equal(
+    chromiumArgument,
+    "--host-resolver-rules=MAP scribe-pr-99-915966395449.us-east5.run.app [2607:f8b0:4004:c1b::65]",
+  );
+});

--- a/web/e2e/deployed-readiness.mjs
+++ b/web/e2e/deployed-readiness.mjs
@@ -1,6 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
 import { chromium } from "@playwright/test";
 
+import { configureCanonicalIPv6Routing } from "./deployed-readiness-routing.mjs";
+
 const scriptStartedAt = Date.now();
 const readinessSmokeFixtureBase64 = "iVBORw0KGgoAAAANSUhEUgAAAoAAAACgAQAAAAC0heCRAAAEJElEQVRo3u3ZTW7jNhQH8CdwMMyiCGeZRWBO0QtkmUVhoTdJb+DuvDAsqVpkOVeiposeoyx6gHJJoILY/yNpx2oKS2mnm4IGDMRO9LOp90E8hsIXflABC1jAAhawgAUs4P8abJtQTaT9lrSjOowyTGLkH6jGa1d7Cu6grCdt9SiWwYmUpyNJgJJBh+tpJAVQ4bXVkDLYCkfNIhiv25IAKBi01Fg6kMQvZAaVO0gGSdh1oL0EDdXmAjQA5ZtArz+Z41YBVL3Dn3dOt+NhA3Aj8doovxXuIKyvJ/mbGVeAdWjDpHqAHYPC6yqMWvIzgXWVQRWGFVEG2GUwfkMxKnEB/giwc4fqDaAO/SUoJyUvwF76esigDGYNWEUwB6XJYL6H1DBo3OEDgrKlxqhlEPkrkIych8ifZpLTLUc452EjX8Aa+VAtg0hsEbM7JvYZ1PxksI/g3RPAdYkd2gjqvOQTmEtvBlqU5ArQyz4tOaVNuod5yQ1Hi8H7j8iGqQqmXgYnBm8ZHF7Ae8VPgFTFKN8TQOSXWwEG2aUoJzDl4alSRgaRh5sIDpy1S+AfQZ4qZXhdKSNRrBQGpzD8sgL0R8m13J3uYaplzdUiEsi1rBnU3U8rluxjt1EDoly9dBvdA+wdPWobuw1A2pAwa7pN7IfKzPuh7gB2AGu7536o2zeA6HhHdORZx9YDwIFBt+eOnUBpXsf0b97hPUXZ/WlPEbynaAPQOHpgEHuKNvhgNNsVe8q/fRSwgAUsYAELWMACFrCABfwvwQGzAyZ/HudrTGWTCG0QmNUqDJ6Y7PIBUDDC4G0b/BYzEAbV6yDmCAZlwHQhMDj3DGI6vgTJrgW96gFWPEZFEENyPwF0GZQZfDrKCIoF0AL0CcQaaRQY7LpJvQZ3W7UerAImTtVG0G3FgFk32GMC+QAIC3H7bxOISVeHdaBpAu2FbcQwMhjCDHy80+tA96l330HaKpvBzmCuPYNVBg83dQRpAXS7Z+meIojhm3bChsFGsJmDR3oT+O4RYB3ePfQM+roVViYwHgAhKEfMrAze7A6kr4E/PEtrL0DDAYgnPjOw4utWgd//LK1r3t9F8H11Bk+JHQ+A8A1P4FcPC+DXn9UrcNe0qJg52HTrQA9wcI28SaDge+gfmh5X6wjGEyV8SJ3B2w/Xg+K/+awM1ZJilOUF6DOYDoD8GaQFUFjVAmxjHjLYdP5jADgmcPMXUC2DuiXNICpFPgNEfwD4+z8ExwyaWMsAUcsR/DUvWdP8Hqp2GRQjg9xtZOjRbcYqtJWNsU0nStxtIsgF1V7vNqN0Wo5K2tgPAaIfTjOwTWBzAs0KcIqgjCA6dgabGRhWgpN0WwZd3FMA8v8usLFUWHcCTdpTzqC9Dn6BRwELWMACFrCABSxgAQtYwAIWsIAFLCAefwL3udqwYaAJQwAAAABJRU5ErkJggg==";
 const readinessSmokeFixtureSHA256 = "e3f3bb2b5ade3c15af262a76ad58b720e7eb3b3d079802df04f1dd50be917b2d";
@@ -1126,7 +1128,11 @@ try {
   baseURL = previewBaseURL();
   if (!baseURL) throw new Error("invalid target");
 
-  browser = await chromium.launch({ headless: true });
+  const chromiumIPv6Argument = await configureCanonicalIPv6Routing(baseURL.hostname);
+  browser = await chromium.launch({
+    args: [chromiumIPv6Argument],
+    headless: true,
+  });
   if (mainScenarioTimedOut) {
     await browser.close().catch(() => undefined);
     throw new Error("main scenario deadline exceeded");

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2948,9 +2948,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -3989,9 +3989,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

- add an isolated preview-only dual-stack VPC and external IPv6 `/64` for the managed browser runner
- force canonical `run.app` traffic over a validated AAAA route while retaining IPv4 NAT only for DNS and IPv4-only fixtures
- own Google’s required `roles/compute.publicIpAdmin` Cloud Run service-agent grant once in protected foundation state
- retain the legacy preview browser network additively so Direct VPC teardown does not block the prerequisite apply
- validate both Terraform roots and cover routing, allowlist, and IPv4/IPv6 teardown contracts

## Focused validation

- `./ci/terraform-check.sh`
- `bash ci/browser-readiness-contract_test.sh`
- `bash ci/deploy-local-destroy_test.sh`
- `bash ci/ops-security-contracts.sh`
- `bash ci/project-foundation-contract_test.sh`
- shell syntax, Terraform formatting, and `git diff --check`

Per the repository trust boundary, protected preview applies Terraform from protected `main`, not PR-head Terraform. This narrow prerequisite therefore needs direct CI review and an exact-commit merge first; PR #99 will then be rebased onto it and provide the first live managed IPv6 proof.