### PR TITLE
Reuse preview VPC for browser readiness

### DIFF
--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -323,6 +323,15 @@ jobs:
           ./ci/verify-cloud-backups.sh
           echo "TF_VAR_terraform_state_backup_audited=true" >> "$GITHUB_ENV"
 
+      - name: Normalize shared dev Terraform moved state
+        if: inputs.mode == 'apply' && inputs.pr_number != ''
+        shell: bash
+        env:
+          DEPLOY_BRANCH: ${{ inputs.checkout_ref }}
+          VAULT_BOOTSTRAP_MODE: root-token
+        run: |
+          ./ci/capture-command-log.sh ".github-artifacts/terraform/dev-moved-state.log" make tf-dev BRANCH="$DEPLOY_BRANCH" ACTION=normalize-moves
+
       - name: Reconcile shared preview Vault runtime access
         if: inputs.mode == 'apply' && inputs.pr_number != ''
         shell: bash

--- a/ci/browser-readiness-contract_test.sh
+++ b/ci/browser-readiness-contract_test.sh
@@ -489,6 +489,17 @@ require_fixed 'rejects timeout configurations outside the frontend platform boun
 
 require_fixed 'normalized_browser_readiness_image = trimspace(var.browser_readiness_image)' terraform/readiness.tf
 require_pattern 'browser_readiness_enabled[[:space:]]+= local\.is_preview_workspace && local\.normalized_browser_readiness_image != ""' terraform/readiness.tf
+require_fixed 'resource "google_compute_network" "application"' terraform/application_network.tf
+require_fixed 'resource "google_compute_subnetwork" "application"' terraform/application_network.tf
+require_fixed 'from = module.scribe.module.gcp[0].google_compute_network.cloud-compose[0]' terraform/application_network_moved.tf
+require_fixed 'to   = google_compute_network.application' terraform/application_network_moved.tf
+require_fixed 'from = module.scribe.module.gcp[0].google_compute_subnetwork.cloud-compose[0]' terraform/application_network_moved.tf
+require_fixed 'to   = google_compute_subnetwork.application' terraform/application_network_moved.tf
+require_fixed 'create                   = false' terraform/main.tf
+require_fixed 'name                     = google_compute_network.application.self_link' terraform/main.tf
+require_fixed 'subnetwork               = google_compute_subnetwork.application.self_link' terraform/main.tf
+forbid_pattern 'resource "google_compute_network" "browser_readiness' terraform/readiness.tf
+forbid_pattern 'resource "google_compute_(address|router|router_nat|subnetwork)" "browser_readiness_ipv6"' terraform/readiness.tf
 require_fixed 'browser_readiness_image = local.normalized_browser_readiness_image' terraform/outputs.tf
 require_fixed 'image = local.normalized_browser_readiness_image' terraform/readiness.tf
 require_pattern 'browser_readiness_name_hash[[:space:]]+= substr\(sha256\("\$\{var\.name\}:\$\{local\.workspace_slug\}"\), 0, 8\)' terraform/readiness.tf
@@ -499,9 +510,7 @@ require_fixed 'substr("probe-browser-${local.workspace_slug}", 0, 21)' terraform
 for resource in google_compute_address google_compute_router google_compute_router_nat google_compute_subnetwork google_cloud_run_v2_job google_service_account; do
   require_pattern "resource \"${resource}\" \"browser_readiness\"" terraform/readiness.tf
 done
-for resource in google_compute_address google_compute_network google_compute_router google_compute_router_nat google_compute_subnetwork; do
-  require_pattern "resource \"${resource}\" \"browser_readiness_ipv6\"" terraform/readiness.tf
-done
+require_pattern 'resource "google_compute_firewall" "browser_readiness_isolation"' terraform/readiness.tf
 for required in \
   'nat_ip_allocate_option             = "MANUAL_ONLY"' \
   'nat_ips                            = [google_compute_address.browser_readiness[0].self_link]' \
@@ -515,45 +524,54 @@ for required in \
 done
 require_fixed 'value = "--dns-result-order=ipv6first --no-network-family-autoselection"' terraform/readiness.tf
 for required in \
-  'auto_create_subnetworks = false' \
-  'routing_mode            = "REGIONAL"' \
-  'mtu                     = 1460' \
-  'network                  = google_compute_network.browser_readiness_ipv6[0].self_link' \
+  'network                  = google_compute_network.application.self_link' \
   'stack_type               = "IPV4_IPV6"' \
   'ipv6_access_type         = "EXTERNAL"' \
   'strcontains(self.external_ipv6_prefix, ":")' \
-  'nat_ips                            = [google_compute_address.browser_readiness_ipv6[0].self_link]' \
-  'name                    = google_compute_subnetwork.browser_readiness_ipv6[0].self_link' \
-  'network    = local.browser_readiness_ipv6_network_resource_name' \
-  'subnetwork = local.browser_readiness_ipv6_subnetwork_resource_name' \
-  'google_compute_router_nat.browser_readiness_ipv6'; do
+  'network    = local.browser_readiness_network_resource_name' \
+  'subnetwork = local.browser_readiness_subnetwork_resource_name' \
+  'tags       = [local.browser_readiness_network_tag]'; do
   require_fixed "$required" terraform/readiness.tf
 done
-require_fixed 'google_compute_subnetwork.browser_readiness_ipv6[0].external_ipv6_prefix' terraform/readiness.tf
+require_fixed 'google_compute_subnetwork.browser_readiness[0].external_ipv6_prefix' terraform/readiness.tf
 browser_readiness_allowlist="$(sed -n \
   '/browser_readiness_allowed_ips =/,/] : \[\]/p' terraform/readiness.tf)"
-[ "$(rg -c -F 'google_compute_subnetwork.browser_readiness_ipv6[0].external_ipv6_prefix' \
+[ "$(rg -c -F 'google_compute_subnetwork.browser_readiness[0].external_ipv6_prefix' \
   <<<"$browser_readiness_allowlist")" -eq 1 ] ||
   fail "the preview PPB allowlist must contain exactly the dedicated external IPv6 prefix"
 if rg -q 'google_compute_address' <<<"$browser_readiness_allowlist"; then
   fail "a browser NAT IPv4 address still grants preview PPB ingress"
 fi
-preview_ipv6_resources="$(sed -n \
-  '/^resource "google_compute_network" "browser_readiness_ipv6"/,/^resource "google_service_account" "backend_readiness"/p' \
+protected_browser_resources="$(sed -n \
+  '/^resource "google_compute_subnetwork" "browser_readiness"/,/^resource "google_service_account" "backend_readiness"/p' \
   terraform/readiness.tf)"
-forbid_pattern 'module\.scribe' /dev/stdin <<<"$preview_ipv6_resources"
-require_fixed 'ip_cidr_range = var.browser_readiness_subnet_cidr' terraform/readiness.tf
+forbid_pattern 'module\.scribe' /dev/stdin <<<"$protected_browser_resources"
+require_fixed 'ip_cidr_range            = var.browser_readiness_subnet_cidr' terraform/readiness.tf
 require_fixed 'private_ip_google_access = false' terraform/readiness.tf
-[ "$(rg -c -F 'private_ip_google_access = false' terraform/readiness.tf)" -eq 2 ] ||
-  fail "both the legacy and dual-stack browser subnets must keep explicit Private Google Access settings"
+[ "$(rg -c -F 'private_ip_google_access = false' terraform/readiness.tf)" -eq 1 ] ||
+  fail "the dedicated dual-stack browser subnet must keep Private Google Access disabled"
+require_fixed 'private_ip_google_access = true' terraform/application_network.tf
 require_fixed 'check "browser_readiness_subnet_isolated"' terraform/readiness.tf
 require_fixed 'setintersection(' terraform/readiness.tf
+for required in \
+  'direction          = "EGRESS"' \
+  'priority           = 100' \
+  'destination_ranges = [var.network_ip_cidr_range]' \
+  'target_tags        = [local.browser_readiness_network_tag]' \
+  'protocol = "all"'; do
+  require_fixed "$required" terraform/readiness.tf
+done
+browser_readiness_job="$(sed -n \
+  '/^resource "google_cloud_run_v2_job" "browser_readiness"/,/^resource "google_cloud_run_v2_job" "backend_readiness"/p' \
+  terraform/readiness.tf)"
+for required in \
+  'google_compute_firewall.browser_readiness_isolation,' \
+  'google_compute_router_nat.browser_readiness,'; do
+  require_fixed "$required" /dev/stdin <<<"$browser_readiness_job"
+done
 [ "$(rg -c -F 'subnetwork = local.readiness_subnetwork_resource_name' terraform/readiness.tf)" -eq 2 ] ||
   fail "only the backend and OCR probes may use the application subnet"
-if rg -Fq 'subnetwork = local.browser_readiness_subnetwork_resource_name' terraform/readiness.tf; then
-  fail "the browser job still attaches to the legacy browser subnet"
-fi
-[ "$(rg -c -F 'subnetwork = local.browser_readiness_ipv6_subnetwork_resource_name' terraform/readiness.tf)" -eq 1 ] ||
+[ "$(rg -c -F 'subnetwork = local.browser_readiness_subnetwork_resource_name' terraform/readiness.tf)" -eq 1 ] ||
   fail "only the browser probe may use the isolated dual-stack subnet"
 require_fixed 'power_button_allowed_ips = distinct(concat(var.allowed_ips, local.browser_readiness_allowed_ips))' terraform/main.tf
 [ "$(rg -l 'browser_readiness_allowed_ips' terraform/*.tf | wc -l)" -eq 2 ] ||

--- a/ci/capture-command-log_test.sh
+++ b/ci/capture-command-log_test.sh
@@ -90,8 +90,8 @@ while IFS=: read -r workflow line_number invocation; do
   esac
 done < <(rg -n --no-heading 'make tf-(dev|prod|preview)' "$ROOT_DIR/.github/workflows" | sed "s#^${ROOT_DIR}/##")
 
-[ "$workflow_calls" -eq 9 ] ||
-  fail "expected all nine GitHub Terraform entry points, found ${workflow_calls}"
+[ "$workflow_calls" -eq 10 ] ||
+  fail "expected all ten GitHub Terraform entry points, found ${workflow_calls}"
 if rg -q -- 'deploy-local\.sh' "$ROOT_DIR/.github/workflows"; then
   fail "a workflow bypasses the shared make-based Terraform entry points"
 fi

--- a/ci/cloud-compose-snapshot-contract_test.sh
+++ b/ci/cloud-compose-snapshot-contract_test.sh
@@ -33,6 +33,12 @@ printf '%s\n' "$scribe_module" | grep -Eq 'production[[:space:]]*=[[:space:]]*lo
   fail "Scribe does not pass its production workspace decision to cloud-compose"
 printf '%s\n' "$scribe_module" | grep -Eq 'enabled[[:space:]]*=[[:space:]]*var\.run_snapshots' ||
   fail "Scribe does not pass the reviewed snapshot flag to cloud-compose"
+printf '%s\n' "$scribe_module" | grep -Eq 'create[[:space:]]*=[[:space:]]*false' ||
+  fail "Scribe still asks cloud-compose to create the root-owned application network"
+printf '%s\n' "$scribe_module" | grep -Eq 'name[[:space:]]*=[[:space:]]*google_compute_network\.application\.self_link' ||
+  fail "Scribe does not pass the root-owned application VPC to cloud-compose"
+printf '%s\n' "$scribe_module" | grep -Eq 'subnetwork[[:space:]]*=[[:space:]]*google_compute_subnetwork\.application\.self_link' ||
+  fail "Scribe does not pass the root-owned application subnet to cloud-compose"
 grep -Eq 'is_prod_workspace[[:space:]]*=[[:space:]]*terraform\.workspace[[:space:]]*==[[:space:]]*"prod"' terraform/main.tf ||
   fail "the production workspace predicate is not exact"
 grep -Eq 'cloud_compose_machine_type[[:space:]]*=[[:space:]]*local\.is_preview_workspace[[:space:]]*\?[[:space:]]*var\.preview_machine_type[[:space:]]*:[[:space:]]*var\.machine_type' terraform/main.tf ||
@@ -53,6 +59,26 @@ for machine_type_variables in "$module_variables" "$provider_variables" "$module
   grep -Eq '^[[:space:]]*"n2d-standard-2",[[:space:]]*$' "$machine_type_variables" ||
     fail "the initialized cloud-compose machine allowlist does not accept n2d-standard-2: ${machine_type_variables}"
 done
+
+# The browser's external /64 is a PPB input, so Scribe must own the physical
+# application VPC above the module. Guard the pinned module's reviewed
+# existing-network lookup path before a future dependency update can silently
+# recreate the VPC or broaden application ingress to the browser subnet.
+grep -Eq 'create[[:space:]]*=[[:space:]]*optional\(bool,[[:space:]]*true\)' "$provider_variables" ||
+  fail "the initialized cloud-compose provider no longer exposes existing-network mode"
+grep -Eq 'create_network[[:space:]]*=[[:space:]]*local\.gcp_network\.create' "$provider_main" ||
+  fail "cloud-compose no longer forwards existing-network mode to its GCP module"
+grep -Eq '^data "google_compute_network" "selected"' "$module_main" ||
+  fail "the initialized cloud-compose module no longer resolves a caller-owned network"
+grep -Eq '^data "google_compute_subnetwork" "selected"' "$module_main" ||
+  fail "the initialized cloud-compose module no longer resolves a caller-owned subnet"
+grep -Eq 'local\.create_network[[:space:]]*\?[[:space:]]*google_compute_network\.cloud-compose\[0\]\.self_link[[:space:]]*:' "$module_main" ||
+  fail "cloud-compose no longer selects the resolved caller-owned network self link"
+grep -Eq 'local\.create_network[[:space:]]*\?[[:space:]]*google_compute_subnetwork\.cloud-compose\[0\]\.self_link[[:space:]]*:' "$module_main" ||
+  fail "cloud-compose no longer selects the resolved caller-owned subnet self link"
+cloud_run_ingress="$(sed -n '/^resource "google_compute_firewall" "allow-cloud-run-ingress"/,/^}/p' "$module_main")"
+printf '%s\n' "$cloud_run_ingress" | grep -Fq 'source_ranges = [local.cloud_run_subnetwork_cidr]' ||
+  fail "cloud-compose no longer limits VM ingress from Cloud Run to the application subnet"
 n2d_disk_precondition="$(
   sed -n \
     '/startswith(var\.machine_type, "e2").*startswith(var\.machine_type, "n2d")/,/error_message = "E2 and N2D/p' \

--- a/ci/deploy-local-destroy_test.sh
+++ b/ci/deploy-local-destroy_test.sh
@@ -80,7 +80,9 @@ case "${1:-}" in
   destroy)
     case "${TF_TEST_DESTROY_MODE:-success}" in
       success) ;;
-      fail-once|always-fail|serverless-fail-once|serverless-browser-fail-once|serverless-browser-ipv6-fail-once|serverless-browser-ipv6-wrong-subnet|serverless-always-fail|serverless-mixed|serverless-wrong-subnet)
+      fail-once|always-fail|serverless-fail-once|serverless-always-fail|serverless-mixed|serverless-wrong-subnet|\
+      serverless-browser-fail-once|serverless-browser-ipv6-fail-once|serverless-browser-wrong-subnet|serverless-browser-ipv6-wrong-subnet|\
+      serverless-browser-v6-fail-once|serverless-browser-v6-ipv6-fail-once|serverless-browser-v6-wrong-subnet|serverless-browser-v6-ipv6-wrong-subnet)
         attempts=0
         if [ -f "${TF_TEST_DESTROY_ATTEMPTS_FILE}" ]; then
           read -r attempts <"${TF_TEST_DESTROY_ATTEMPTS_FILE}" || true
@@ -102,11 +104,31 @@ case "${1:-}" in
           exit 1
         fi
         if [ "${TF_TEST_DESTROY_MODE}" = "serverless-browser-ipv6-fail-once" ] && [ "$attempts" -eq 1 ]; then
+          echo "Error: Error when reading or editing Subnetwork 'projects/example-project/regions/us-east5/subnetworks/scribe-pr-75-browser-9aac94f3': googleapi: Error 400: already used by 'projects/example-project/regions/us-east5/addresses/serverless-ipv6-scribe-pr-75-browser-9aac94f3', resourceInUseByAnotherResource" >&2
+          exit 1
+        fi
+        if [ "${TF_TEST_DESTROY_MODE}" = "serverless-browser-v6-fail-once" ] && [ "$attempts" -eq 1 ]; then
+          echo "Error: Error when reading or editing Subnetwork 'projects/example-project/regions/us-east5/subnetworks/scribe-pr-75-browser-v6-9aac94f3': googleapi: Error 400: already used by 'projects/example-project/regions/us-east5/addresses/serverless-ipv4-scribe-pr-75-browser-v6-9aac94f3', resourceInUseByAnotherResource" >&2
+          exit 1
+        fi
+        if [ "${TF_TEST_DESTROY_MODE}" = "serverless-browser-v6-ipv6-fail-once" ] && [ "$attempts" -eq 1 ]; then
           echo "Error: Error when reading or editing Subnetwork 'projects/example-project/regions/us-east5/subnetworks/scribe-pr-75-browser-v6-9aac94f3': googleapi: Error 400: already used by 'projects/example-project/regions/us-east5/addresses/serverless-ipv6-scribe-pr-75-browser-v6-9aac94f3', resourceInUseByAnotherResource" >&2
           exit 1
         fi
+        if [ "${TF_TEST_DESTROY_MODE}" = "serverless-browser-wrong-subnet" ]; then
+          echo "Error: Error when reading or editing Subnetwork 'projects/example-project/regions/us-east5/subnetworks/scribe-pr-75-browser-deadbeef': googleapi: Error 400: already used by 'projects/example-project/regions/us-east5/addresses/serverless-ipv4-scribe-pr-75-browser-deadbeef', resourceInUseByAnotherResource" >&2
+          exit 1
+        fi
         if [ "${TF_TEST_DESTROY_MODE}" = "serverless-browser-ipv6-wrong-subnet" ]; then
-          echo "Error: Error when reading or editing Subnetwork 'projects/example-project/regions/us-east5/subnetworks/scribe-pr-76-browser-v6-9aac94f3': googleapi: Error 400: already used by 'projects/example-project/regions/us-east5/addresses/serverless-ipv6-scribe-pr-76-browser-v6-9aac94f3', resourceInUseByAnotherResource" >&2
+          echo "Error: Error when reading or editing Subnetwork 'projects/example-project/regions/us-east5/subnetworks/scribe-pr-75-browser-deadbeef': googleapi: Error 400: already used by 'projects/example-project/regions/us-east5/addresses/serverless-ipv6-scribe-pr-75-browser-deadbeef', resourceInUseByAnotherResource" >&2
+          exit 1
+        fi
+        if [ "${TF_TEST_DESTROY_MODE}" = "serverless-browser-v6-wrong-subnet" ]; then
+          echo "Error: Error when reading or editing Subnetwork 'projects/example-project/regions/us-east5/subnetworks/scribe-pr-75-browser-v6-deadbeef': googleapi: Error 400: already used by 'projects/example-project/regions/us-east5/addresses/serverless-ipv4-scribe-pr-75-browser-v6-deadbeef', resourceInUseByAnotherResource" >&2
+          exit 1
+        fi
+        if [ "${TF_TEST_DESTROY_MODE}" = "serverless-browser-v6-ipv6-wrong-subnet" ]; then
+          echo "Error: Error when reading or editing Subnetwork 'projects/example-project/regions/us-east5/subnetworks/scribe-pr-75-browser-v6-deadbeef': googleapi: Error 400: already used by 'projects/example-project/regions/us-east5/addresses/serverless-ipv6-scribe-pr-75-browser-v6-deadbeef', resourceInUseByAnotherResource" >&2
           exit 1
         fi
         if [ "${TF_TEST_DESTROY_MODE}" = "serverless-wrong-subnet" ]; then
@@ -368,8 +390,8 @@ grep -F 'waiting for Google to release its serverless IPv4/IPv6 subnet reservati
   "${TEST_DIR}/destroy-browser-serverless-retry.err" >/dev/null
 grep -F 'workspace delete pr-75' "${terraform_log}" >/dev/null
 
-# The additive dual-stack network has its own deterministic subnet. Either a
-# provider-managed IPv4 or IPv6 reservation receives the same bounded wait.
+# The same dual-stack browser subnet can be held by the provider's IPv6
+# reservation. Address family never broadens the exact-subnet classifier.
 rm -f "${TEST_DIR}/destroy-attempts" "${TEST_DIR}/sleep.log"
 : >"${terraform_log}"
 if ! TF_TEST_DESTROY_MODE=serverless-browser-ipv6-fail-once run_destroy valid \
@@ -384,6 +406,32 @@ grep -F 'waiting for Google to release its serverless IPv4/IPv6 subnet reservati
   "${TEST_DIR}/destroy-browser-ipv6-serverless-retry.err" >/dev/null
 grep -F 'workspace delete pr-75' "${terraform_log}" >/dev/null
 
+# Workspaces that reached the retired additive network rollout can still own a
+# deterministic `-browser-v6-` subnet. Keep that exact historical name on the
+# bounded cleanup path for either managed address family, without making it a
+# current resource name again. A partial rollout can predate the recorded
+# browser image, so teardown classification must not depend on that output.
+historical_empty_browser_state="${TEST_DIR}/deployment-inputs-empty-browser.json"
+jq '.browser_readiness_image = ""' "${state_file}" >"${historical_empty_browser_state}"
+for historical_route in ipv4 ipv6; do
+  rm -f "${TEST_DIR}/destroy-attempts" "${TEST_DIR}/sleep.log"
+  : >"${terraform_log}"
+  historical_mode=serverless-browser-v6-fail-once
+  [ "$historical_route" = ipv4 ] || historical_mode=serverless-browser-v6-ipv6-fail-once
+  historical_error="${TEST_DIR}/destroy-historical-preview-browser-${historical_route}.err"
+  TF_TEST_STATE_FILE="$historical_empty_browser_state" \
+    TF_TEST_DESTROY_MODE="$historical_mode" run_destroy valid \
+      "${TEST_DIR}/destroy-historical-preview-browser-${historical_route}.out" \
+      "$historical_error" || {
+    echo "historical preview ${historical_route} browser-v6 subnet cleanup delay was not classified" >&2
+    exit 1
+  }
+  [ "$(grep -Fc 'destroy -auto-approve' "${terraform_log}")" -eq 2 ]
+  [ "$(grep -Fc 'output -json deployment_inputs' "${terraform_log}")" -eq 1 ]
+  grep -Fx 'sleep 300' "${TEST_DIR}/sleep.log" >/dev/null
+  grep -F 'waiting for Google to release its serverless IPv4/IPv6 subnet reservation' \
+    "$historical_error" >/dev/null
+done
 rm -f "${TEST_DIR}/destroy-attempts" "${TEST_DIR}/sleep.log"
 : >"${terraform_log}"
 if TF_TEST_DESTROY_MODE=serverless-always-fail run_destroy valid \
@@ -401,7 +449,13 @@ if grep -F 'workspace delete pr-75' "${terraform_log}" >/dev/null; then
   exit 1
 fi
 
-for destroy_mode in serverless-mixed serverless-wrong-subnet serverless-browser-ipv6-wrong-subnet; do
+for destroy_mode in \
+  serverless-mixed \
+  serverless-wrong-subnet \
+  serverless-browser-wrong-subnet \
+  serverless-browser-ipv6-wrong-subnet \
+  serverless-browser-v6-wrong-subnet \
+  serverless-browser-v6-ipv6-wrong-subnet; do
   rm -f "${TEST_DIR}/destroy-attempts" "${TEST_DIR}/sleep.log"
   : >"${terraform_log}"
   if TF_TEST_DESTROY_MODE="$destroy_mode" run_destroy valid \

--- a/ci/normalize-terraform-moved-state.sh
+++ b/ci/normalize-terraform-moved-state.sh
@@ -85,8 +85,9 @@ esac
 root_moved="$scribe_dir/moved.tf"
 repo_moved="$terraform_dir/cloud_compose_moved.tf"
 repo_root_moved="$terraform_dir/scribe_root_moved.tf"
+repo_application_network_moved="$terraform_dir/application_network_moved.tf"
 gcp_moved="$gcp_dir/moved.tf"
-for moved_file in "$root_moved" "$repo_moved" "$repo_root_moved" "$gcp_moved"; do
+for moved_file in "$root_moved" "$repo_moved" "$repo_root_moved" "$gcp_moved" "$repo_application_network_moved"; do
   [[ -f "$moved_file" ]] || die "required moved declaration file is missing: $moved_file"
 done
 
@@ -303,6 +304,147 @@ preflight_moved_file() {
   rm -f -- "$parsed_file"
 }
 
+declare -a application_network_lineage_aliases=()
+
+append_application_network_lineage_alias() {
+  local candidate=$1
+  local existing
+
+  [[ -n "$candidate" ]] || die "application-network lineage contains an empty address"
+  for existing in "${application_network_lineage_aliases[@]}"; do
+    [[ "$existing" == "$candidate" ]] && return 0
+  done
+  application_network_lineage_aliases+=("$candidate")
+}
+
+# The application network and subnet finish outside module.scribe, but an old
+# workspace can still hold either object at the original module root, the
+# intermediate uncounted GCP module, or the current counted GCP module. Detect
+# every conflicting source/destination combination before the first state mv;
+# otherwise discovering a root destination only in the final phase would leave
+# the earlier lineage hops partially committed.
+preflight_application_network_moves() {
+  local uncounted_module='module.scribe.module.gcp'
+  local counted_module='module.scribe.module.gcp[0]'
+  local uncounted_prefix="$uncounted_module."
+  local counted_prefix="$counted_module."
+  local upstream_records repository_records gcp_records application_records
+  local record_phase move_source move_destination
+  local final_source final_destination alias alias_index
+  local repository_inner_source repository_execution_source
+  local candidate candidate_is_source
+  local lineage_source_count lineage_destination_count
+  local lineage_source_sample lineage_second_source_sample lineage_destination_sample
+
+  upstream_records=$(mktemp)
+  repository_records=$(mktemp)
+  gcp_records=$(mktemp)
+  application_records=$(mktemp)
+  temporary_files+=("$upstream_records" "$repository_records" "$gcp_records" "$application_records")
+
+  parse_moved_file upstream-root module.scribe "$root_moved" >"$upstream_records" ||
+    die "could not safely parse moved declarations in $root_moved"
+  parse_moved_file repository-inner '' "$repo_moved" >"$repository_records" ||
+    die "could not safely parse moved declarations in $repo_moved"
+  parse_moved_file upstream-gcp "$counted_module" "$gcp_moved" >"$gcp_records" ||
+    die "could not safely parse moved declarations in $gcp_moved"
+  parse_moved_file application-network '' "$repo_application_network_moved" >"$application_records" ||
+    die "could not safely parse moved declarations in $repo_application_network_moved"
+
+  while IFS=$'\t' read -r record_phase final_source final_destination; do
+    [[ "$record_phase" == application-network \
+      && "$final_source" == "$counted_prefix"* \
+      && "$final_destination" != module.* ]] || {
+      die "application-network moved declaration must move one counted GCP-module object to the root: $final_source -> $final_destination"
+    }
+
+    application_network_lineage_aliases=()
+    append_application_network_lineage_alias "$final_source"
+    alias_index=0
+    while (( alias_index < ${#application_network_lineage_aliases[@]} )); do
+      alias=${application_network_lineage_aliases[$alias_index]}
+
+      # process_repository_hop first moves the whole uncounted module. Include
+      # the same inner address before that hop even when no repository-specific
+      # count/for_each declaration exists for this resource.
+      if [[ "$alias" == "$counted_prefix"* ]]; then
+        append_application_network_lineage_alias "$uncounted_prefix${alias#"$counted_prefix"}"
+      fi
+
+      while IFS=$'\t' read -r record_phase move_source move_destination; do
+        [[ "$record_phase" == upstream-root ]] ||
+          die "invalid parsed upstream-root declaration in $root_moved"
+        if address_matches "$move_destination" "$alias"; then
+          append_application_network_lineage_alias "$move_source"
+        fi
+      done <"$upstream_records"
+
+      while IFS=$'\t' read -r record_phase move_source move_destination; do
+        [[ "$record_phase" == repository-inner \
+          && "$move_source" == "$uncounted_prefix"* \
+          && "$move_destination" == "$counted_prefix"* ]] || {
+          die "repository moved declaration does not describe the expected counted GCP module hop: $move_source -> $move_destination"
+        }
+        if address_matches "$move_destination" "$alias"; then
+          repository_inner_source=${move_source#"$uncounted_prefix"}
+          repository_execution_source="$counted_prefix$repository_inner_source"
+          append_application_network_lineage_alias "$repository_execution_source"
+          append_application_network_lineage_alias "$move_source"
+        fi
+      done <"$repository_records"
+
+      while IFS=$'\t' read -r record_phase move_source move_destination; do
+        [[ "$record_phase" == upstream-gcp ]] ||
+          die "invalid parsed upstream-gcp declaration in $gcp_moved"
+        if address_matches "$move_destination" "$alias"; then
+          append_application_network_lineage_alias "$move_source"
+        fi
+      done <"$gcp_records"
+
+      (( alias_index += 1 ))
+    done
+
+    lineage_source_count=0
+    lineage_destination_count=0
+    lineage_source_sample=''
+    lineage_second_source_sample=''
+    lineage_destination_sample=''
+    for candidate in "${state_addresses[@]}"; do
+      candidate_is_source=false
+      for alias in "${application_network_lineage_aliases[@]}"; do
+        if address_matches "$alias" "$candidate"; then
+          candidate_is_source=true
+          break
+        fi
+      done
+      if [[ "$candidate_is_source" == true ]]; then
+        (( lineage_source_count += 1 ))
+        if [[ -z "$lineage_source_sample" ]]; then
+          lineage_source_sample=$candidate
+        elif [[ -z "$lineage_second_source_sample" ]]; then
+          lineage_second_source_sample=$candidate
+        fi
+      fi
+      if address_matches "$final_destination" "$candidate"; then
+        (( lineage_destination_count += 1 ))
+        [[ -n "$lineage_destination_sample" ]] || lineage_destination_sample=$candidate
+      fi
+    done
+
+    if (( lineage_source_count > 0 && lineage_destination_count > 0 )); then
+      die "application-network preflight conflict: source lineage $lineage_source_sample and root destination $lineage_destination_sample both exist"
+    fi
+    if (( lineage_source_count > 1 )); then
+      die "application-network preflight conflict: source aliases $lineage_source_sample and $lineage_second_source_sample both exist for root destination $final_destination"
+    fi
+    if (( lineage_destination_count > 1 )); then
+      die "application-network preflight conflict: root destination $final_destination has multiple state objects"
+    fi
+  done <"$application_records"
+
+  rm -f -- "$upstream_records" "$repository_records" "$gcp_records" "$application_records"
+}
+
 process_repository_hop() {
   local uncounted_module='module.scribe.module.gcp'
   local counted_module='module.scribe.module.gcp[0]'
@@ -345,9 +487,11 @@ process_repository_hop() {
 
 load_state
 preflight_moved_file repository-root '' "$repo_root_moved"
+preflight_application_network_moves
 process_moved_file repository-root '' "$repo_root_moved"
 process_moved_file upstream-root module.scribe "$root_moved"
 process_repository_hop
 process_moved_file upstream-gcp 'module.scribe.module.gcp[0]' "$gcp_moved"
+process_moved_file application-network '' "$repo_application_network_moved"
 
 printf 'Terraform moved-state normalization completed without provider refresh or apply.\n'

--- a/ci/normalize-terraform-moved-state_test.sh
+++ b/ci/normalize-terraform-moved-state_test.sh
@@ -16,6 +16,7 @@ prepare_work_dir() {
   cp -- "$build_dir/terraform.tfstate" "$destination/terraform.tfstate"
   cp -- "$fixture/cloud_compose_moved.tf" "$destination/cloud_compose_moved.tf"
   cp -- "$fixture/scribe_root_moved.tf" "$destination/scribe_root_moved.tf"
+  cp -- "$fixture/application_network_moved.tf" "$destination/application_network_moved.tf"
   cp -R -- "$fixture/installed/." "$destination/.terraform/modules/cloud-compose-fixture/"
   cp -- "$fixture/modules.json" "$destination/.terraform/modules/modules.json"
 }
@@ -51,6 +52,8 @@ terraform -chdir="$work_dir" state rm \
 
 mapfile -t actual < <(terraform -chdir="$work_dir" state list)
 expected=(
+  'terraform_data.application_network'
+  'terraform_data.application_subnetwork'
   'terraform_data.root_app_policy[0]'
   'terraform_data.root_app_role[0]'
   'terraform_data.root_app_viewer'
@@ -74,6 +77,75 @@ after=$(terraform -chdir="$work_dir" state pull)
   exit 1
 }
 grep -q 'Already normalized' "$work_dir/second.log"
+
+# A workspace may already have completed the historical root-module and
+# counted-module hops before this root-ownership phase is introduced. Prove
+# those exact current cloud-compose addresses still converge to the same root
+# destinations without a provider refresh.
+counted_dir="$test_root/counted-current"
+prepare_work_dir "$counted_dir"
+terraform -chdir="$counted_dir" state rm \
+  terraform_data.root_unindexed_conflict_seed \
+  'terraform_data.root_indexed_conflict_seed[0]' >/dev/null
+"$repo_root/ci/normalize-terraform-moved-state.sh" "$counted_dir" >"$counted_dir/historical-normalize.log"
+terraform -chdir="$counted_dir" state mv \
+  terraform_data.application_network \
+  'module.scribe.module.gcp[0].terraform_data.application_network[0]' >/dev/null
+terraform -chdir="$counted_dir" state mv \
+  terraform_data.application_subnetwork \
+  'module.scribe.module.gcp[0].terraform_data.application_subnetwork[0]' >/dev/null
+"$repo_root/ci/normalize-terraform-moved-state.sh" "$counted_dir" >"$counted_dir/normalize.log"
+mapfile -t counted_actual < <(terraform -chdir="$counted_dir" state list)
+if [[ "${counted_actual[*]}" != "${expected[*]}" ]]; then
+  printf 'unexpected current-counted normalized state:\n' >&2
+  printf '  %s\n' "${counted_actual[@]}" >&2
+  exit 1
+fi
+
+# A destination collision must fail before any historical address is changed.
+# Exercise every source layer that can feed the final root-owned network move;
+# assert_conflict_is_safe compares the complete state byte-for-byte.
+for lineage in legacy uncounted counted-pre-inner counted-final; do
+  conflict_dir="$test_root/application-network-${lineage}-conflict"
+  prepare_work_dir "$conflict_dir"
+  terraform -chdir="$conflict_dir" state rm \
+    'terraform_data.root_indexed_conflict_seed[0]' >/dev/null
+  terraform -chdir="$conflict_dir" state mv \
+    terraform_data.root_unindexed_conflict_seed \
+    terraform_data.application_network >/dev/null
+  case "$lineage" in
+    legacy) ;;
+    uncounted)
+      terraform -chdir="$conflict_dir" state mv \
+        module.scribe.terraform_data.application_network \
+        module.scribe.module.gcp.terraform_data.application_network >/dev/null
+      ;;
+    counted-pre-inner)
+      terraform -chdir="$conflict_dir" state mv \
+        module.scribe.terraform_data.application_network \
+        'module.scribe.module.gcp[0].terraform_data.application_network' >/dev/null
+      ;;
+    counted-final)
+      terraform -chdir="$conflict_dir" state mv \
+        module.scribe.terraform_data.application_network \
+        'module.scribe.module.gcp[0].terraform_data.application_network[0]' >/dev/null
+      ;;
+  esac
+  assert_conflict_is_safe "$conflict_dir" \
+    'application-network preflight conflict: source lineage'
+done
+
+# Multiple historical aliases are equally unsafe even when the root
+# destination is absent. Reject the mixed lineage before normalizing either.
+alias_conflict_dir="$test_root/application-network-alias-conflict"
+prepare_work_dir "$alias_conflict_dir"
+terraform -chdir="$alias_conflict_dir" state rm \
+  'terraform_data.root_indexed_conflict_seed[0]' >/dev/null
+terraform -chdir="$alias_conflict_dir" state mv \
+  terraform_data.root_unindexed_conflict_seed \
+  module.scribe.module.gcp.terraform_data.application_network >/dev/null
+assert_conflict_is_safe "$alias_conflict_dir" \
+  'application-network preflight conflict: source aliases'
 
 viewer_conflict_dir="$test_root/viewer-conflict"
 prepare_work_dir "$viewer_conflict_dir"

--- a/ci/ops-security-contracts.sh
+++ b/ci/ops-security-contracts.sh
@@ -106,10 +106,13 @@ test "$(rg -c 'network    = local\.readiness_network_resource_name' terraform/re
   fail "backend and OCR readiness must use the canonical application network resource name"
 test "$(rg -c 'subnetwork = local\.readiness_subnetwork_resource_name' terraform/readiness.tf)" -eq 2 ||
   fail "backend and OCR readiness jobs must use the canonical application subnetwork resource name"
-test "$(rg -c 'network    = local\.browser_readiness_ipv6_network_resource_name' terraform/readiness.tf)" -eq 1 ||
-  fail "browser readiness must use only its isolated dual-stack network resource name"
-test "$(rg -c 'subnetwork = local\.browser_readiness_ipv6_subnetwork_resource_name' terraform/readiness.tf)" -eq 1 ||
+test "$(rg -c 'network    = local\.browser_readiness_network_resource_name' terraform/readiness.tf)" -eq 1 ||
+  fail "browser readiness must use only its environment application network resource name"
+test "$(rg -c 'subnetwork = local\.browser_readiness_subnetwork_resource_name' terraform/readiness.tf)" -eq 1 ||
   fail "browser readiness must use only its isolated dual-stack subnetwork resource name"
+require_pattern 'tags       = \[local\.browser_readiness_network_tag\]' terraform/readiness.tf
+require_pattern 'resource "google_compute_firewall" "browser_readiness_isolation"' terraform/readiness.tf
+require_pattern 'destination_ranges = \[var\.network_ip_cidr_range\]' terraform/readiness.tf
 forbid_pattern 'network    = module\.scribe\.network\.self_link' terraform/readiness.tf
 forbid_pattern 'subnetwork = module\.scribe\.network\.subnetwork' terraform/readiness.tf
 require_pattern 'readiness_jobs = \{' terraform/monitoring.tf

--- a/ci/preview-vault-runtime-contract_test.sh
+++ b/ci/preview-vault-runtime-contract_test.sh
@@ -171,10 +171,16 @@ for required in \
   'go-version-file: \.go-version' \
   '\./ci/resolve-shared-vault\.sh "\$vault_workspace"' \
   'VAULT_BOOTSTRAP_MODE: root-token' \
+  'make tf-dev BRANCH="[$]DEPLOY_BRANCH" ACTION=normalize-moves' \
   'make tf-dev-vault-preview-runtime BRANCH="[$]DEPLOY_BRANCH" ACTION=apply'; do
   rg -q "$required" <<<"$trusted_deploy_job" ||
     fail "trusted deploy job is missing preview Vault control: ${required}"
 done
+normalize_step="$(sed -n \
+  '/name: Normalize shared dev Terraform moved state/,/name: Reconcile shared preview Vault runtime access/p' \
+  .github/workflows/terraform-deploy.yaml)"
+rg -Fq 'VAULT_BOOTSTRAP_MODE: root-token' <<<"$normalize_step" ||
+  fail "shared dev moved-state normalization does not use the reviewed root-token bootstrap path"
 rg -Fq "group: \${{ inputs.environment_name == 'preview' && 'terraform-preview-dev-shared' || format('terraform-deploy-{0}', inputs.site_name) }}" <<<"$trusted_deploy_job" ||
   fail "the entire shared preview reconciliation and deployment path is not serialized"
 
@@ -188,12 +194,13 @@ rg -Fq 'unexpected key "queue" for "concurrency" section' .github/actionlint.yam
   fail "the actionlint compatibility exception does not match only its unsupported queue syntax"
 
 go_setup_line="$(rg -n 'name: Set up Go for preview Vault reconciliation' .github/workflows/terraform-deploy.yaml | cut -d: -f1)"
+normalize_line="$(rg -n 'name: Normalize shared dev Terraform moved state' .github/workflows/terraform-deploy.yaml | cut -d: -f1)"
 reconcile_line="$(rg -n 'name: Reconcile shared preview Vault runtime access' .github/workflows/terraform-deploy.yaml | cut -d: -f1)"
 vault_login_line="$(rg -n 'name: Login to Vault' .github/workflows/terraform-deploy.yaml | cut -d: -f1)"
 preview_apply_line="$(rg -n 'name: Run preview Terraform$' .github/workflows/terraform-deploy.yaml | cut -d: -f1)"
 readiness_line="$(rg -n 'name: Verify frontend, backend, and OCR readiness' .github/workflows/terraform-deploy.yaml | cut -d: -f1)"
-((go_setup_line < reconcile_line && reconcile_line < vault_login_line && vault_login_line < preview_apply_line && preview_apply_line < readiness_line)) ||
-  fail "shared preview Vault reconciliation is not inside the locked deploy/readiness critical section"
+((go_setup_line < normalize_line && normalize_line < reconcile_line && reconcile_line < vault_login_line && vault_login_line < preview_apply_line && preview_apply_line < readiness_line)) ||
+  fail "shared dev state normalization and preview Vault reconciliation are not inside the locked deploy/readiness critical section"
 
 preview_deploy_call="$(sed -n '/^  deploy:/,/^  destroy:/p' .github/workflows/terraform-preview.yaml)"
 rg -q 'checkout_ref: \$\{\{ needs\.prepare\.outputs\.base_sha \}\}' <<<"$preview_deploy_call" ||

--- a/ci/terraform-moved-refresh_test.sh
+++ b/ci/terraform-moved-refresh_test.sh
@@ -8,14 +8,21 @@ TEST_DIR="$(mktemp -d)"
 trap 'rm -rf "${TEST_DIR}"' EXIT HUP INT TERM
 
 cp "${FIXTURE_DIR}/before/main.tf" "${TEST_DIR}/main.tf"
+cp -R "${FIXTURE_DIR}/modules" "${TEST_DIR}/modules"
 
 terraform -chdir="${TEST_DIR}" init -backend=false -input=false >/dev/null
 terraform -chdir="${TEST_DIR}" apply -auto-approve -input=false >/dev/null
 
-if ! terraform -chdir="${TEST_DIR}" state list | grep -Fx 'terraform_data.legacy' >/dev/null; then
-  echo "Moved-resource fixture did not create the legacy state address." >&2
-  exit 1
-fi
+initial_state_list="$(terraform -chdir="${TEST_DIR}" state list)"
+for legacy_address in \
+  'terraform_data.legacy' \
+  'module.scribe.module.gcp[0].terraform_data.application_network[0]' \
+  'module.scribe.module.gcp[0].terraform_data.application_subnetwork[0]'; do
+  if ! printf '%s\n' "${initial_state_list}" | grep -Fx "${legacy_address}" >/dev/null; then
+    echo "Moved-resource fixture did not create ${legacy_address}." >&2
+    exit 1
+  fi
+done
 
 cp "${FIXTURE_DIR}/after/main.tf" "${TEST_DIR}/main.tf"
 
@@ -42,21 +49,45 @@ terraform -chdir="${TEST_DIR}" plan \
   -out="${refresh_plan}" >/dev/null
 
 terraform -chdir="${TEST_DIR}" show -no-color "${refresh_plan}" >"${TEST_DIR}/refresh-plan.out"
-if ! grep -F 'terraform_data.legacy has moved to terraform_data.normalized' "${TEST_DIR}/refresh-plan.out" >/dev/null; then
-  echo "Saved refresh-only plan did not contain the expected state-address move." >&2
-  sed -n '1,80p' "${TEST_DIR}/refresh-plan.out" >&2
-  exit 1
-fi
+for expected_move in \
+  'terraform_data.legacy has moved to terraform_data.normalized' \
+  'module.scribe.module.gcp[0].terraform_data.application_network[0] has moved to terraform_data.application_network' \
+  'module.scribe.module.gcp[0].terraform_data.application_subnetwork[0] has moved to terraform_data.application_subnetwork'; do
+  if ! grep -F "${expected_move}" "${TEST_DIR}/refresh-plan.out" >/dev/null; then
+    echo "Saved refresh-only plan did not contain the expected move: ${expected_move}" >&2
+    sed -n '1,120p' "${TEST_DIR}/refresh-plan.out" >&2
+    exit 1
+  fi
+done
 
 terraform -chdir="${TEST_DIR}" apply -input=false "${refresh_plan}" >/dev/null
 
 state_list="$(terraform -chdir="${TEST_DIR}" state list)"
-if ! printf '%s\n' "${state_list}" | grep -Fx 'terraform_data.normalized' >/dev/null; then
-  echo "Refresh-only apply did not persist the normalized resource address." >&2
-  exit 1
-fi
-if printf '%s\n' "${state_list}" | grep -Fx 'terraform_data.legacy' >/dev/null; then
-  echo "Refresh-only apply left the legacy resource address in state." >&2
+for normalized_address in \
+  'terraform_data.normalized' \
+  'terraform_data.application_network' \
+  'terraform_data.application_subnetwork'; do
+  if ! printf '%s\n' "${state_list}" | grep -Fx "${normalized_address}" >/dev/null; then
+    echo "Refresh-only apply did not persist ${normalized_address}." >&2
+    exit 1
+  fi
+done
+for legacy_address in \
+  'terraform_data.legacy' \
+  'module.scribe.module.gcp[0].terraform_data.application_network[0]' \
+  'module.scribe.module.gcp[0].terraform_data.application_subnetwork[0]'; do
+  if printf '%s\n' "${state_list}" | grep -Fx "${legacy_address}" >/dev/null; then
+    echo "Refresh-only apply left ${legacy_address} in state." >&2
+    exit 1
+  fi
+done
+
+if ! terraform -chdir="${TEST_DIR}" plan \
+  -detailed-exitcode \
+  -input=false \
+  >"${TEST_DIR}/full-after.out" 2>&1; then
+  echo "Full plan found drift after refresh-only moved-resource normalization." >&2
+  sed -n '1,120p' "${TEST_DIR}/full-after.out" >&2
   exit 1
 fi
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -118,23 +118,32 @@ staged PR-head fixture. The source SHA tags the image and Terraform records its
 resolved digest. The script runs only after the preview apply in a no-IAM,
 preview-only Playwright job with digest-pinned runtime and browser dependencies.
 Its dedicated service account has no project, storage, Vault, Pub/Sub, or OCR
-IAM grants. An independent browser-only VPC gives its dual-stack `/26` one
-external IPv6 `/64`; that dedicated `/64` is the sole browser range added to
-the preview's PPB policy. The singleton project foundation grants
+IAM grants. Each preview reuses its root-owned application VPC instead of
+consuming a second project-wide network quota slot. Cloud Compose consumes that
+VPC and its application subnet as existing resources; reviewed `moved` blocks
+transfer their Terraform ownership from the nested module to the root without
+recreating either object. The browser job attaches to a dedicated,
+non-overlapping dual-stack `/26` in that VPC. Its network-interface tag selects
+an egress firewall deny for the exact application subnet CIDR, so the untrusted
+preview runner cannot use the common preview VPC to reach private application
+addresses. The browser subnet receives one external IPv6 `/64`; that
+preview-owned `/64` is the sole browser range added to the preview's PPB policy,
+so production and other previews are not widened. The singleton project
+foundation grants
 `roles/compute.publicIpAdmin` only to Google's Cloud Run service agent, as
-required for external-IPv6 Direct VPC addresses; no preview workspace or
-application identity owns that project-wide grant. Cloud NAT exists only for
-fixed public DNS and reviewed IPv4-only fixture origins. The exact-head runner
-must force the canonical `scribe-pr-*` host over AAAA and fail closed if it
-cannot, because Public Cloud NAT does not translate
-`run.app` traffic. A protected helper retries fixed public AAAA resolution for
-at most two minutes, accepts at most 32 public-global answers, selects one
-deterministic address for Chromium's exact-host resolver rule, and disables
-Node's IPv4 family race for Playwright API requests. Production and other
-previews are not widened. The former
-application-VPC browser subnet and NAT remain state-managed during the
-additive migration, but the job is detached from them and their `/32` is no
-longer allowlisted.
+required for external-IPv6 Direct VPC addresses; no preview workspace, human,
+deploy, or application identity owns that project-wide grant. A subnet-scoped
+Cloud NAT and reserved regional IPv4 address exist only for fixed public DNS
+and reviewed IPv4-only fixture origins. The exact-head runner must force the
+canonical `scribe-pr-*` host over AAAA and fail closed if it cannot, because
+Public Cloud NAT does not translate `run.app` traffic. A protected helper
+retries fixed public AAAA resolution for at most two minutes, accepts at most
+32 public-global answers, selects one deterministic address for Chromium's
+exact-host resolver rule, and disables Node's IPv4 family race for Playwright
+API requests. Direct VPC plus Cloud NAT does not destination-filter arbitrary
+public IPv4 browser egress, so the additional boundaries are the runner's exact
+configured HTTPS origin, host-only session cookie, no-data identity, and
+bounded product script.
 
 The scenario uses preview-anonymous auth and leaves the upload selector on
 resolver-backed `Default` (`0`), then verifies the resulting durable

--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -142,13 +142,16 @@ or `serverless-ipv6-*` address and `resourceInUseByAnotherResource`, the
 protected job retries every five minutes for up to two hours using the same
 already-validated deployment inputs. Every Terraform error in that attempt
 must identify either the exact current preview application subnet, its exact
-deterministic legacy browser subnet, or its exact deterministic dual-stack
-browser subnet, plus a managed address; mixed or differently scoped failures
-retain the ordinary bound. The wait retains the shared preview serialization
-lock and the job-scoped deploy identity so no other preview can replace shared runtime
-bindings during a partial teardown. Its preview-only timeout leaves a one-hour
-execution and cleanup margin beyond the two-hour sleep budget; other deploy
-modes retain their shorter timeout. After Terraform succeeds, the workflow
+deterministic dual-stack browser subnet, or its exact deterministic retired
+`browser-v6` subnet from the previous independent-network design, plus a
+managed address. The retired name is accepted only by this bounded teardown
+classifier; no active job attaches to it and it grants no PPB access. Mixed or
+differently scoped failures retain the ordinary bound. The wait retains the
+shared preview serialization lock and the job-scoped deploy identity so no
+other preview can replace shared runtime bindings during a partial teardown.
+Its preview-only timeout leaves a one-hour execution and cleanup margin beyond
+the two-hour sleep budget; other deploy modes retain their shorter timeout.
+After Terraform succeeds, the workflow
 mints new short-lived Vault proxy, identity, and client tokens before removing
 the preview namespace, rather than reusing credentials created before the wait.
 Other errors retain the ordinary three-attempt bound. If Google still has not
@@ -213,6 +216,11 @@ backup policy, then applies only the transitive address changes declared by
 Scribe and the pinned cloud-compose module with `terraform state mv`. It does
 not refresh providers or plan/apply infrastructure, is retry-idempotent, and
 fails if both sides of a move are populated.
+
+Protected preview apply performs this state-only normalization for the shared
+`dev` workspace, after the state-backup audit and before its targeted Vault
+runtime reconciliation. The production and preview workspace applies remain
+full-graph operations, so Terraform persists their declared moves natively.
 
 The trusted `pull_request_target` workflow initially belongs to the protected
 base revision, so GitHub's automatic environment record is not evidence for the
@@ -469,26 +477,32 @@ The PR-head script runs only later in the preview-only Playwright job. The
 runtime and browser are digest-pinned, run as `pwuser`, and receive only the
 preview's canonical HTTPS origin. A dedicated Cloud Run job uses a dedicated
 service account with no project, storage, Vault, Pub/Sub, or OCR IAM grants.
-Direct VPC egress attaches only this job to a dedicated, non-overlapping preview
-`/26` in an independent custom VPC. The subnet is dual stack and receives one
-external IPv6 `/64`; Terraform appends only that dedicated `/64` to this
-preview's PPB ingress allowlist. The standalone project foundation owns the
-documented `roles/compute.publicIpAdmin` grant for Google's Cloud Run service
-agent. It is never recreated by a preview workspace, and no human, deploy, or
-application identity receives that role. Cloud NAT and a reserved regional
-IPv4 address cover the same subnet only for fixed public DNS and reviewed
-IPv4-only fixture origins. Public Cloud NAT automatically uses Private Google
-Access rather than translating
-`run.app`, so the exact-head runner must force the canonical preview host over
-AAAA and fail closed if that path is unavailable. The protected routing helper
-accepts at most 32 public-global AAAA answers, maps only the exact canonical
-host in Chromium, and disables Node's IPv4 family race for Playwright API
-requests. The VM, backend probe, OCR
-probe, application subnet, production, and other previews cannot use the
-dedicated `/64`. The original application-VPC browser subnet, address, router,
-and NAT stay state-managed during this additive migration to avoid blocking an
-apply on delayed Direct VPC address release; the job is detached from that
-subnet and its former `/32` is no longer allowlisted.
+The preview's existing application VPC and application subnet are root-owned
+Terraform resources. Reviewed `moved` blocks transfer their addresses from the
+nested Cloud Compose module without recreating either object, and the module
+consumes their exact self-links with network creation disabled. This
+quota-neutral ownership allows the browser job to use a dedicated,
+non-overlapping dual-stack `/26` in the same preview VPC. The job's Direct VPC
+interface carries an isolation tag, and an egress firewall deny targeted to
+that tag blocks the exact private application subnet CIDR. The browser subnet
+receives one external IPv6 `/64`; Terraform appends only that preview-owned
+`/64` to this preview's PPB ingress allowlist, so production and other previews
+are not widened. The standalone project foundation owns the documented
+`roles/compute.publicIpAdmin` grant for Google's Cloud Run service agent. It is
+never recreated by a preview workspace, and no human, deploy, or application
+identity receives that role. A reserved regional IPv4 address and
+subnet-scoped Cloud NAT cover only the browser subnet for fixed public DNS and
+reviewed IPv4-only fixture origins. The canonical `run.app` host is forced over
+AAAA because Public Cloud NAT does not translate it. The protected routing
+helper accepts at most 32 public-global AAAA answers, maps only the exact
+canonical host in Chromium, and disables Node's IPv4 family race for Playwright
+API requests. The VM, backend probe, OCR probe, and application subnet cannot
+use a browser `/64`; production and other previews cannot use this preview's
+range. A retired deterministic `browser-v6` subnet name remains recognized
+only by the bounded destroy classifier so an interrupted rollout of the
+earlier independent-network design can wait for Google-managed Direct VPC
+address release. No active job attaches to that retired subnet and it grants
+no PPB access.
 
 The job authenticates through the existing isolated
 `AUTH_PREVIEW_ANONYMOUS` workspace. It leaves context selection on `Default`

--- a/docs/reference/quality-gates.md
+++ b/docs/reference/quality-gates.md
@@ -189,20 +189,25 @@ production default Ollama OCR request. Fixture contracts require authenticated
 requests, real image bytes, JPEG validation, non-empty model output, and Ollama
 `done=true`; a health-only response is not deployment evidence.
 
-Preview readiness also runs a digest-pinned Playwright image in an independent
-custom VPC. Its non-overlapping dual-stack `/26` receives one external IPv6
-`/64`, and only that environment-owned `/64` is added to the preview PPB
-policy. A static Cloud NAT address remains available only for fixed public DNS
-and reviewed IPv4-only fixture origins; `run.app` is forced over AAAA because
-Public Cloud NAT does not translate Google service traffic. A protected,
-unit-tested helper bounds and validates public-global AAAA answers, supplies
-Chromium's exact-host
+Preview readiness also runs a digest-pinned Playwright image in the preview's
+root-owned application VPC, avoiding an additional project-wide network quota
+slot. Reviewed state moves transfer the existing VPC and application subnet
+from nested-module ownership to the root without resource replacement, and
+Cloud Compose consumes their exact self-links. The browser job uses a
+dedicated, non-overlapping dual-stack `/26`; its interface tag selects an
+egress firewall deny for the exact private application subnet CIDR. The browser
+subnet receives one external IPv6 `/64`, and only that preview-owned `/64` is
+added to the preview's PPB policy. Its reserved IPv4 address and subnet-scoped
+Cloud NAT remain available only for fixed public DNS and reviewed IPv4-only
+fixture origins; `run.app` is forced over AAAA because Public Cloud NAT does
+not translate Google service traffic. A protected, unit-tested helper bounds
+and validates public-global AAAA answers, supplies Chromium's exact-host
 mapping, and disables Node IPv4 racing for Playwright API requests. The
 singleton foundation binds Google's required `roles/compute.publicIpAdmin`
-only to the managed Cloud Run service agent, never to preview state or an
-application identity. The detached legacy browser subnet and NAT remain
-state-managed during the additive migration but grant no PPB access. Trusted
-orchestration fetches only the
+only to the managed Cloud Run service agent, never to preview state, deploy
+identities, or application identities. The retired deterministic `browser-v6`
+subnet is recognized only by bounded teardown recovery and grants no active
+job attachment or PPB access. Trusted orchestration fetches only the
 readiness script at the exact resolved same-repository PR-head SHA before cloud
 authentication, walks its exact commit tree, requires unique tree parents and a
 `100644` source blob, and reconciles the bounded Contents payload with that blob

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -146,17 +146,26 @@ verified plan before auto-applying that exact saved plan. It does not invoke
 image resolution, pull, or build tooling; remote-state, provider, backup-policy,
 and Vault authentication prerequisites may still be required. Refresh and
 ordinary destroy require an existing selected workspace and never create one.
+The final Scribe move phase transfers the existing application VPC and subnet
+from the counted Cloud Compose module addresses to root ownership only after
+the module's historical address moves have converged. Cloud Compose then
+consumes those exact resources with network creation disabled; normalization
+does not recreate either object. Protected preview orchestration normalizes the
+shared `dev` state after its backup audit and before targeted Vault maintenance;
+production and preview workspace applies retain the full Terraform graph.
 Destroy retains its one validated input snapshot across at most three attempts
 for ordinary failures. A Google-managed `serverless-ipv4-*` or
 `serverless-ipv6-*` dependency on the exact preview application subnet, exact
-legacy browser subnet, or exact independent dual-stack browser subnet receives
-up to 25 attempts, five minutes apart, because Cloud Run Direct VPC address
+deterministic dual-stack browser subnet, or exact deterministic retired
+`browser-v6` subnet from the previous independent-network design receives up
+to 25 attempts, five minutes apart, because Cloud Run Direct VPC address
 release can take two hours; it does not authorize deletion of the
-provider-managed address. Only preview destroy
-receives the extended workflow timeout; other deployment modes keep the
-ordinary bound. A preview workspace is deleted only after destroy succeeds. If
-an interrupted teardown already removed the current output, the protected
-preview workflow's explicit
+provider-managed address. The retired name is a teardown-only classifier and
+grants no active job attachment or PPB access. Only preview destroy receives
+the extended workflow timeout; other deployment modes keep the ordinary bound.
+A preview workspace is deleted only after destroy succeeds. If an interrupted
+teardown already removed the current output, the protected preview workflow's
+explicit
 `recover-destroy` action can read the newest valid lower-serial, same-lineage
 output from the versioned state object's history. It does not restore or
 overwrite state and is not available for production. When a prior protected
@@ -283,6 +292,15 @@ from the four documented additive legacy defaults.
   the recorded production source and runtime inputs.
 - [backup-verification.yaml](../.github/workflows/backup-verification.yaml)
   exercises the independent production recovery boundary.
+
+Protected preview workspaces retain one root-owned per-environment application
+VPC. The managed browser job attaches to a dedicated, non-overlapping
+dual-stack `/26` in that VPC, and its interface tag selects an egress firewall
+deny for the exact private application subnet CIDR. Only the browser subnet's
+external IPv6 `/64` enters that preview's PPB allowlist. A reserved IPv4 address
+and subnet-scoped Cloud NAT serve fixed DNS and reviewed IPv4-only fixture
+origins without widening PPB or another environment. This topology adds no
+browser-only VPC to the project's network quota.
 
 A manual protected production `mode=plan` reuses current runtime image digests
 and does not build, publish, promote, or apply. Production destroy is not

--- a/terraform/application_network.tf
+++ b/terraform/application_network.tf
@@ -1,0 +1,19 @@
+# The application VPC must be a root-owned dependency rather than an output of
+# module.scribe. The protected browser subnet contributes its external IPv6
+# prefix to the module's PPB policy, so leaving network ownership inside that
+# module would create a dependency cycle on every fresh workspace.
+resource "google_compute_network" "application" {
+  project                 = var.project_id
+  name                    = var.name
+  auto_create_subnetworks = false
+  mtu                     = 1460
+}
+
+resource "google_compute_subnetwork" "application" {
+  project                  = var.project_id
+  region                   = var.region
+  name                     = var.name
+  network                  = google_compute_network.application.self_link
+  ip_cidr_range            = var.network_ip_cidr_range
+  private_ip_google_access = true
+}

--- a/terraform/application_network_moved.tf
+++ b/terraform/application_network_moved.tf
@@ -1,0 +1,14 @@
+# cloud-compose 1.8.1 can consume an existing network and subnet. Preserve the
+# exact deployed objects while transferring only their Terraform ownership to
+# the root configuration; no VPC or application subnet is recreated. Keep this
+# file moved-block-only so the state-only normalizer can process it as its final
+# phase after historical upstream and counted-module address migrations.
+moved {
+  from = module.scribe.module.gcp[0].google_compute_network.cloud-compose[0]
+  to   = google_compute_network.application
+}
+
+moved {
+  from = module.scribe.module.gcp[0].google_compute_subnetwork.cloud-compose[0]
+  to   = google_compute_subnetwork.application
+}

--- a/terraform/deploy-local.sh
+++ b/terraform/deploy-local.sh
@@ -917,15 +917,18 @@ if [[ ! "$data_generation" =~ ^canonical-v(1|2)$ ]]; then
 fi
 
 browser_readiness_subnet_name=""
-browser_readiness_ipv6_subnet_name=""
-if [ "$environment" = "preview" ] && [[ "$browser_readiness_image" =~ [^[:space:]] ]]; then
+historical_browser_readiness_ipv6_subnet_name=""
+if [ "$action" = "destroy" ] && [ "$environment" = "preview" ]; then
   browser_readiness_name_hash="$(sha256_text "${TF_VAR_name}:${target_workspace}")"
   browser_readiness_name_prefix="${TF_VAR_name:0:46}"
   browser_readiness_name_prefix="${browser_readiness_name_prefix%-}"
   browser_readiness_subnet_name="${browser_readiness_name_prefix}-browser-${browser_readiness_name_hash:0:8}"
-  browser_readiness_ipv6_name_prefix="${TF_VAR_name:0:43}"
-  browser_readiness_ipv6_name_prefix="${browser_readiness_ipv6_name_prefix%-}"
-  browser_readiness_ipv6_subnet_name="${browser_readiness_ipv6_name_prefix}-browser-v6-${browser_readiness_name_hash:0:8}"
+  # Retain only the deterministic name of the retired dedicated-IPv6 subnet.
+  # A partially deployed historical workspace can still be waiting for a
+  # Google-managed Direct VPC address to release it during destroy.
+  historical_browser_readiness_ipv6_name_prefix="${TF_VAR_name:0:43}"
+  historical_browser_readiness_ipv6_name_prefix="${historical_browser_readiness_ipv6_name_prefix%-}"
+  historical_browser_readiness_ipv6_subnet_name="${historical_browser_readiness_ipv6_name_prefix}-browser-v6-${browser_readiness_name_hash:0:8}"
 fi
 
 if [ -n "$dev_external_ocr_impersonators" ]; then
@@ -1080,13 +1083,13 @@ case "$action" in
           serverless_error_seen=true
           app_subnet_marker="/subnetworks/${TF_VAR_name}'"
           browser_subnet_marker="/subnetworks/${browser_readiness_subnet_name}'"
-          browser_ipv6_subnet_marker="/subnetworks/${browser_readiness_ipv6_subnet_name}'"
+          historical_browser_ipv6_subnet_marker="/subnetworks/${historical_browser_readiness_ipv6_subnet_name}'"
           known_serverless_subnet=false
           if [[ "$destroy_diagnostic_line" == *"$app_subnet_marker"* ]] \
             || { [ -n "$browser_readiness_subnet_name" ] \
               && [[ "$destroy_diagnostic_line" == *"$browser_subnet_marker"* ]]; } \
-            || { [ -n "$browser_readiness_ipv6_subnet_name" ] \
-              && [[ "$destroy_diagnostic_line" == *"$browser_ipv6_subnet_marker"* ]]; }; then
+            || { [ -n "$historical_browser_readiness_ipv6_subnet_name" ] \
+              && [[ "$destroy_diagnostic_line" == *"$historical_browser_ipv6_subnet_marker"* ]]; }; then
             known_serverless_subnet=true
           fi
           if [[ "$destroy_diagnostic_line" != *resourceInUseByAnotherResource* ]] \

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -828,7 +828,12 @@ module "scribe" {
     }
 
     network = {
+      create                   = false
+      project_id               = var.project_id
+      name                     = google_compute_network.application.self_link
+      subnetwork               = google_compute_subnetwork.application.self_link
       ip_cidr_range            = var.network_ip_cidr_range
+      mtu                      = google_compute_network.application.mtu
       power_button_allowed_ips = distinct(concat(var.allowed_ips, local.browser_readiness_allowed_ips))
       power_button_ip_depth    = 0
       ssh_ipv4                 = var.allowed_ssh_ipv4

--- a/terraform/readiness.tf
+++ b/terraform/readiness.tf
@@ -17,27 +17,27 @@ locals {
   )
   normalized_browser_readiness_image = trimspace(var.browser_readiness_image)
   browser_readiness_enabled          = local.is_preview_workspace && local.normalized_browser_readiness_image != ""
-  browser_readiness_ipv6_network_resource_name = try(regex(
+  browser_readiness_network_resource_name = try(regex(
     "projects/[^/]+/global/networks/[^/]+$",
-    google_compute_network.browser_readiness_ipv6[0].self_link,
+    google_compute_network.application.self_link,
   ), "")
-  browser_readiness_ipv6_subnetwork_resource_name = try(regex(
+  browser_readiness_subnetwork_resource_name = try(regex(
     "projects/[^/]+/regions/[^/]+/subnetworks/[^/]+$",
-    google_compute_subnetwork.browser_readiness_ipv6[0].self_link,
+    google_compute_subnetwork.browser_readiness[0].self_link,
   ), "")
-  browser_readiness_name_hash          = substr(sha256("${var.name}:${local.workspace_slug}"), 0, 8)
-  browser_readiness_resource_name      = "${trimsuffix(substr(var.name, 0, 46), "-")}-browser-${local.browser_readiness_name_hash}"
-  browser_readiness_ipv6_resource_name = "${trimsuffix(substr(var.name, 0, 43), "-")}-browser-v6-${local.browser_readiness_name_hash}"
-  browser_readiness_job_name           = "${trimsuffix(substr(var.name, 0, 32), "-")}-browser-${local.browser_readiness_name_hash}"
-  browser_readiness_account_id         = "${trimsuffix(substr("probe-browser-${local.workspace_slug}", 0, 21), "-")}-${local.browser_readiness_name_hash}"
+  browser_readiness_name_hash     = substr(sha256("${var.name}:${local.workspace_slug}"), 0, 8)
+  browser_readiness_resource_name = "${trimsuffix(substr(var.name, 0, 46), "-")}-browser-${local.browser_readiness_name_hash}"
+  browser_readiness_job_name      = "${trimsuffix(substr(var.name, 0, 32), "-")}-browser-${local.browser_readiness_name_hash}"
+  browser_readiness_account_id    = "${trimsuffix(substr("probe-browser-${local.workspace_slug}", 0, 21), "-")}-${local.browser_readiness_name_hash}"
+  browser_readiness_network_tag   = "${local.browser_readiness_job_name}-isolated"
   browser_readiness_allowed_ips = local.browser_readiness_enabled ? [
-    google_compute_subnetwork.browser_readiness_ipv6[0].external_ipv6_prefix,
+    google_compute_subnetwork.browser_readiness[0].external_ipv6_prefix,
   ] : []
 }
 
-# Direct VPC egress requires at least a /26. Keep the browser runner outside the
-# application subnet so its public NAT address cannot become an outbound path
-# for the VM, frontend-to-backend probe, or OCR probe.
+# Direct VPC egress requires at least a /26. The browser receives a dedicated
+# dual-stack subnet inside this environment's already-counted VPC, so protected
+# previews do not consume one additional project-wide network quota each.
 check "browser_readiness_subnet_isolated" {
   assert {
     condition = !local.browser_readiness_enabled || try(length(setintersection(
@@ -54,19 +54,33 @@ check "browser_readiness_subnet_isolated" {
 resource "google_compute_subnetwork" "browser_readiness" {
   count = local.browser_readiness_enabled ? 1 : 0
 
-  project       = var.project_id
-  region        = var.region
-  name          = local.browser_readiness_resource_name
-  network       = module.scribe.network.self_link
-  ip_cidr_range = var.browser_readiness_subnet_cidr
-  # Retained unchanged until previews created before the external-IPv6
-  # migration have been destroyed. The browser job no longer attaches here.
+  project                  = var.project_id
+  region                   = var.region
+  name                     = local.browser_readiness_resource_name
+  network                  = google_compute_network.application.self_link
+  ip_cidr_range            = var.browser_readiness_subnet_cidr
+  stack_type               = "IPV4_IPV6"
+  ipv6_access_type         = "EXTERNAL"
   private_ip_google_access = false
+
+  lifecycle {
+    postcondition {
+      condition = (
+        can(cidrhost(self.external_ipv6_prefix, 0)) &&
+        strcontains(self.external_ipv6_prefix, ":") &&
+        endswith(self.external_ipv6_prefix, "/64")
+      )
+      error_message = "The preview browser readiness subnet must receive one canonical external IPv6 /64."
+    }
+  }
 }
 
-# Retain the original address/router/NAT resource addresses during the additive
-# migration so applying the prerequisite never waits for a detached Direct VPC
-# subnet to become deletable. This /32 is no longer in the preview PPB policy.
+# Public Cloud NAT does not translate traffic to run.app: it automatically
+# enables Private Google Access for covered IPv4 ranges, and Cloud Run can then
+# observe 0.0.0.0 instead of the reserved NAT address. The browser therefore
+# forces canonical Scribe traffic over its environment-owned external IPv6
+# /64. This IPv4 address remains only for fixed DNS and reviewed IPv4-only
+# origins and is never included in a PPB policy.
 resource "google_compute_address" "browser_readiness" {
   count = local.browser_readiness_enabled ? 1 : 0
 
@@ -83,7 +97,7 @@ resource "google_compute_router" "browser_readiness" {
   project = var.project_id
   region  = var.region
   name    = local.browser_readiness_resource_name
-  network = module.scribe.network.self_link
+  network = google_compute_network.application.self_link
 }
 
 resource "google_compute_router_nat" "browser_readiness" {
@@ -103,84 +117,22 @@ resource "google_compute_router_nat" "browser_readiness" {
   }
 }
 
-# Public Cloud NAT does not translate traffic to run.app: it automatically
-# enables Private Google Access for covered IPv4 ranges, and Cloud Run can then
-# observe 0.0.0.0 instead of the reserved NAT address. Keep the legacy preview
-# resources above state-addressable during this additive migration, but run the
-# browser in its own dual-stack VPC. The dedicated external /64 is stable for
-# the subnet lifetime and is the only browser range added to this preview's PPB
-# policy. No application, shared, or production subnet can use that range.
-resource "google_compute_network" "browser_readiness_ipv6" {
+# The PR-head preview runner is untrusted. Its network tag and exact egress deny
+# prevent direct access to the environment's private application subnet while
+# preserving public DNS, canonical IPv6, and reviewed fixture traffic.
+resource "google_compute_firewall" "browser_readiness_isolation" {
   count = local.browser_readiness_enabled ? 1 : 0
 
-  project                 = var.project_id
-  name                    = local.browser_readiness_ipv6_resource_name
-  auto_create_subnetworks = false
-  routing_mode            = "REGIONAL"
-  mtu                     = 1460
-}
+  project            = var.project_id
+  name               = "${local.browser_readiness_job_name}-egress"
+  network            = google_compute_network.application.self_link
+  direction          = "EGRESS"
+  priority           = 100
+  destination_ranges = [var.network_ip_cidr_range]
+  target_tags        = [local.browser_readiness_network_tag]
 
-resource "google_compute_subnetwork" "browser_readiness_ipv6" {
-  count = local.browser_readiness_enabled ? 1 : 0
-
-  project                  = var.project_id
-  region                   = var.region
-  name                     = local.browser_readiness_ipv6_resource_name
-  network                  = google_compute_network.browser_readiness_ipv6[0].self_link
-  ip_cidr_range            = var.browser_readiness_subnet_cidr
-  stack_type               = "IPV4_IPV6"
-  ipv6_access_type         = "EXTERNAL"
-  private_ip_google_access = false
-
-  lifecycle {
-    postcondition {
-      condition = (
-        can(cidrhost(self.external_ipv6_prefix, 0)) &&
-        strcontains(self.external_ipv6_prefix, ":") &&
-        endswith(self.external_ipv6_prefix, "/64")
-      )
-      error_message = "The preview browser readiness subnet must receive one canonical external IPv6 /64."
-    }
-  }
-}
-
-# The browser still needs IPv4 egress for fixed public DNS and reviewed
-# cross-origin fixtures that do not publish AAAA records. This NAT is not an
-# ingress credential: canonical Scribe traffic is explicitly forced over IPv6
-# by the PR-head runner.
-resource "google_compute_address" "browser_readiness_ipv6" {
-  count = local.browser_readiness_enabled ? 1 : 0
-
-  project      = var.project_id
-  region       = var.region
-  name         = local.browser_readiness_ipv6_resource_name
-  address_type = "EXTERNAL"
-  network_tier = "PREMIUM"
-}
-
-resource "google_compute_router" "browser_readiness_ipv6" {
-  count = local.browser_readiness_enabled ? 1 : 0
-
-  project = var.project_id
-  region  = var.region
-  name    = local.browser_readiness_ipv6_resource_name
-  network = google_compute_network.browser_readiness_ipv6[0].self_link
-}
-
-resource "google_compute_router_nat" "browser_readiness_ipv6" {
-  count = local.browser_readiness_enabled ? 1 : 0
-
-  project                            = var.project_id
-  region                             = var.region
-  name                               = local.browser_readiness_ipv6_resource_name
-  router                             = google_compute_router.browser_readiness_ipv6[0].name
-  nat_ip_allocate_option             = "MANUAL_ONLY"
-  nat_ips                            = [google_compute_address.browser_readiness_ipv6[0].self_link]
-  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
-
-  subnetwork {
-    name                    = google_compute_subnetwork.browser_readiness_ipv6[0].self_link
-    source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
+  deny {
+    protocol = "all"
   }
 }
 
@@ -266,16 +218,17 @@ resource "google_cloud_run_v2_job" "browser_readiness" {
       vpc_access {
         egress = "ALL_TRAFFIC"
         network_interfaces {
-          network    = local.browser_readiness_ipv6_network_resource_name
-          subnetwork = local.browser_readiness_ipv6_subnetwork_resource_name
+          network    = local.browser_readiness_network_resource_name
+          subnetwork = local.browser_readiness_subnetwork_resource_name
+          tags       = [local.browser_readiness_network_tag]
         }
       }
     }
   }
 
   depends_on = [
+    google_compute_firewall.browser_readiness_isolation,
     google_compute_router_nat.browser_readiness,
-    google_compute_router_nat.browser_readiness_ipv6,
     google_service_account.browser_readiness,
     module.scribe,
   ]

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -59,9 +59,10 @@ frontend_gar_image     = "us-docker.pkg.dev/your-gcp-project-id/internal/scribe-
 # Use a canonical /24 through /28: Terraform reserves .1 for the bridge
 # gateway, .2 for Traefik, and the upper half for dynamic containers.
 network_ip_cidr_range = "10.42.0.0/24"
-# Keep the preview-only browser runner on a non-overlapping dedicated /26.
+# Keep the protected preview browser runner on a non-overlapping dedicated /26
+# inside that environment's root-owned application VPC.
 browser_readiness_subnet_cidr = "10.43.0.0/26"
-compose_network_cidr  = "172.30.0.0/24"
+compose_network_cidr          = "172.30.0.0/24"
 
 # Runtime admission defaults come from ../config.yaml. Omit them here so a
 # copied tfvars file follows reviewed application-default changes. An operator

--- a/terraform/tests/moved-refresh/after/main.tf
+++ b/terraform/tests/moved-refresh/after/main.tf
@@ -11,6 +11,30 @@ moved {
   to   = terraform_data.normalized
 }
 
+resource "terraform_data" "application_network" {
+  input = "application-network"
+}
+
+resource "terraform_data" "application_subnetwork" {
+  input = "application-subnetwork"
+}
+
+module "scribe" {
+  source = "./modules/scribe"
+
+  create_application_network = false
+}
+
+moved {
+  from = module.scribe.module.gcp[0].terraform_data.application_network[0]
+  to   = terraform_data.application_network
+}
+
+moved {
+  from = module.scribe.module.gcp[0].terraform_data.application_subnetwork[0]
+  to   = terraform_data.application_subnetwork
+}
+
 resource "terraform_data" "maintenance" {
   input = "vault-target"
 }

--- a/terraform/tests/moved-refresh/before/main.tf
+++ b/terraform/tests/moved-refresh/before/main.tf
@@ -6,6 +6,12 @@ resource "terraform_data" "legacy" {
   input = "state-address"
 }
 
+module "scribe" {
+  source = "./modules/scribe"
+
+  create_application_network = true
+}
+
 resource "terraform_data" "maintenance" {
   input = "vault-target"
 }

--- a/terraform/tests/moved-refresh/modules/scribe/main.tf
+++ b/terraform/tests/moved-refresh/modules/scribe/main.tf
@@ -1,0 +1,10 @@
+variable "create_application_network" {
+  type = bool
+}
+
+module "gcp" {
+  count  = 1
+  source = "./modules/gcp"
+
+  create_application_network = var.create_application_network
+}

--- a/terraform/tests/moved-refresh/modules/scribe/modules/gcp/main.tf
+++ b/terraform/tests/moved-refresh/modules/scribe/modules/gcp/main.tf
@@ -1,0 +1,13 @@
+variable "create_application_network" {
+  type = bool
+}
+
+resource "terraform_data" "application_network" {
+  count = var.create_application_network ? 1 : 0
+  input = "application-network"
+}
+
+resource "terraform_data" "application_subnetwork" {
+  count = var.create_application_network ? 1 : 0
+  input = "application-subnetwork"
+}

--- a/terraform/tests/moved-state-normalizer/application_network_moved.tf
+++ b/terraform/tests/moved-state-normalizer/application_network_moved.tf
@@ -1,0 +1,9 @@
+moved {
+  from = module.scribe.module.gcp[0].terraform_data.application_network[0]
+  to   = terraform_data.application_network
+}
+
+moved {
+  from = module.scribe.module.gcp[0].terraform_data.application_subnetwork[0]
+  to   = terraform_data.application_subnetwork
+}

--- a/terraform/tests/moved-state-normalizer/cloud_compose_moved.tf
+++ b/terraform/tests/moved-state-normalizer/cloud_compose_moved.tf
@@ -9,6 +9,16 @@ moved {
 }
 
 moved {
+  from = module.scribe.module.gcp.terraform_data.application_network
+  to   = module.scribe.module.gcp[0].terraform_data.application_network[0]
+}
+
+moved {
+  from = module.scribe.module.gcp.terraform_data.application_subnetwork
+  to   = module.scribe.module.gcp[0].terraform_data.application_subnetwork[0]
+}
+
+moved {
   from = module.scribe.module.gcp.module.ppb
   to   = module.scribe.module.gcp[0].module.ppb[0]
 }

--- a/terraform/tests/moved-state-normalizer/installed/moved.tf
+++ b/terraform/tests/moved-state-normalizer/installed/moved.tf
@@ -14,6 +14,16 @@ moved {
 }
 
 moved {
+  from = terraform_data.application_network
+  to   = module.gcp.terraform_data.application_network
+}
+
+moved {
+  from = terraform_data.application_subnetwork
+  to   = module.gcp.terraform_data.application_subnetwork
+}
+
+moved {
   from = module.ppb
   to   = module.gcp.module.ppb
 }

--- a/terraform/tests/moved-state-normalizer/legacy/main.tf
+++ b/terraform/tests/moved-state-normalizer/legacy/main.tf
@@ -10,6 +10,14 @@ resource "terraform_data" "repository_counted" {
   input = "repository-counted"
 }
 
+resource "terraform_data" "application_network" {
+  input = "application-network"
+}
+
+resource "terraform_data" "application_subnetwork" {
+  input = "application-subnetwork"
+}
+
 module "ppb" {
   source = "./ppb"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -157,7 +157,7 @@ variable "network_ip_cidr_range" {
 }
 
 variable "browser_readiness_subnet_cidr" {
-  description = "Dedicated /26 subnet used only by the preview browser-readiness Cloud Run job and its static-egress Cloud NAT."
+  description = "Dedicated, non-overlapping /26 inside the environment application VPC, used only by the protected preview browser-readiness job and its subnet-scoped Cloud NAT."
   type        = string
   default     = "10.43.0.0/26"
 


### PR DESCRIPTION
Prerequisite for #99.

Reuses each preview environment VPC with a dedicated isolated dual-stack browser subnet, transfers the existing application network and subnet to root Terraform ownership without replacement, and preserves exact state/teardown recovery. The trusted deploy path normalizes shared dev state before targeted maintenance.

This must land before #99 because protected preview Terraform intentionally executes the reviewed base SHA; PR-head code remains limited to the no-IAM browser runner. After this direct CI is green, #99 will be rebased and its protected preview will exercise the live transition.