### PR TITLE
Defer browser IPv6 prefix verification

### DIFF
--- a/.github/workflows/terraform-deploy.yaml
+++ b/.github/workflows/terraform-deploy.yaml
@@ -506,11 +506,6 @@ jobs:
         shell: bash
         env:
           DEPLOY_BRANCH: ${{ inputs.docker_compose_branch }}
-          # A real apply immediately follows this preliminary plan in the same
-          # job whenever mode == 'apply', so it's safe for the browser
-          # readiness IPv6 bootstrap to run here too. A standalone mode ==
-          # 'plan' review never sets this and stays a pure dry run.
-          TF_APPLY_PENDING: ${{ inputs.mode == 'apply' }}
         run: |
           ./ci/capture-command-log.sh ".github-artifacts/terraform/${{ inputs.tf_workspace }}-plan.log" make tf-prod BRANCH="$DEPLOY_BRANCH" ACTION=plan
 
@@ -521,7 +516,6 @@ jobs:
         env:
           DEPLOY_BRANCH: ${{ inputs.docker_compose_branch }}
           PR_NUMBER: ${{ inputs.pr_number }}
-          TF_APPLY_PENDING: ${{ inputs.mode == 'apply' }}
         run: |
           ./ci/capture-command-log.sh ".github-artifacts/terraform/${{ inputs.tf_workspace }}-plan.log" make tf-preview PR="$PR_NUMBER" BRANCH="$DEPLOY_BRANCH" ACTION=plan
 

--- a/ci/browser-readiness-contract_test.sh
+++ b/ci/browser-readiness-contract_test.sh
@@ -533,19 +533,48 @@ for required in \
   'tags       = [local.browser_readiness_network_tag]'; do
   require_fixed "$required" terraform/readiness.tf
 done
-require_fixed 'google_compute_subnetwork.browser_readiness[0].external_ipv6_prefix' terraform/readiness.tf
+require_fixed 'data.google_compute_subnetwork.browser_readiness[0].external_ipv6_prefix' terraform/readiness.tf
 browser_readiness_allowlist="$(sed -n \
   '/browser_readiness_allowed_ips =/,/] : \[\]/p' terraform/readiness.tf)"
-[ "$(rg -c -F 'google_compute_subnetwork.browser_readiness[0].external_ipv6_prefix' \
+[ "$(rg -c -F 'data.google_compute_subnetwork.browser_readiness[0].external_ipv6_prefix' \
   <<<"$browser_readiness_allowlist")" -eq 1 ] ||
   fail "the preview PPB allowlist must contain exactly the dedicated external IPv6 prefix"
 if rg -q 'google_compute_address' <<<"$browser_readiness_allowlist"; then
   fail "a browser NAT IPv4 address still grants preview PPB ingress"
 fi
+if rg -q 'try\(' <<<"$browser_readiness_allowlist"; then
+  fail "the preview PPB allowlist must not fall back around the verified external IPv6 prefix"
+fi
 protected_browser_resources="$(sed -n \
   '/^resource "google_compute_subnetwork" "browser_readiness"/,/^resource "google_service_account" "backend_readiness"/p' \
   terraform/readiness.tf)"
 forbid_pattern 'module\.scribe' /dev/stdin <<<"$protected_browser_resources"
+browser_readiness_prefix_read="$(sed -n \
+  '/^data "google_compute_subnetwork" "browser_readiness"/,/^}/p' \
+  terraform/readiness.tf)"
+for required in \
+  'count = local.browser_readiness_enabled ? 1 : 0' \
+  'project = var.project_id' \
+  'region  = var.region' \
+  'name    = google_compute_subnetwork.browser_readiness[0].name' \
+  'depends_on = [google_compute_subnetwork.browser_readiness]' \
+  'self.stack_type == "IPV4_IPV6"' \
+  'self.ipv6_access_type == "EXTERNAL"' \
+  'can(cidrhost(self.external_ipv6_prefix, 0))' \
+  'strcontains(self.external_ipv6_prefix, ":")' \
+  'endswith(self.external_ipv6_prefix, "/64")'; do
+  require_fixed "$required" /dev/stdin <<<"$browser_readiness_prefix_read"
+done
+managed_browser_subnet="$(sed -n \
+  '/^resource "google_compute_subnetwork" "browser_readiness"/,/^}/p' \
+  terraform/readiness.tf)"
+if rg -q 'postcondition' <<<"$managed_browser_subnet"; then
+  fail "the external IPv6 proof must use a deferred post-apply subnet read rather than stale planned state"
+fi
+forbid_pattern 'bootstrap_browser_readiness_ipv6' terraform/deploy-local.sh
+forbid_pattern 'gcloud[[:space:]]+compute[[:space:]]+networks[[:space:]]+subnets[[:space:]]+update' terraform/deploy-local.sh
+forbid_pattern 'TF_APPLY_PENDING' terraform/deploy-local.sh
+forbid_pattern 'TF_APPLY_PENDING' .github/workflows/terraform-deploy.yaml
 require_fixed 'ip_cidr_range            = var.browser_readiness_subnet_cidr' terraform/readiness.tf
 require_fixed 'private_ip_google_access = false' terraform/readiness.tf
 [ "$(rg -c -F 'private_ip_google_access = false' terraform/readiness.tf)" -eq 1 ] ||

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -299,8 +299,11 @@ dual-stack `/26` in that VPC, and its interface tag selects an egress firewall
 deny for the exact private application subnet CIDR. Only the browser subnet's
 external IPv6 `/64` enters that preview's PPB allowlist. A reserved IPv4 address
 and subnet-scoped Cloud NAT serve fixed DNS and reviewed IPv4-only fixture
-origins without widening PPB or another environment. This topology adds no
-browser-only VPC to the project's network quota.
+origins without widening PPB or another environment. A dependent subnet read is
+deferred across the one-time in-place dual-stack transition, so the saved plan
+consumes and validates the newly allocated `/64` after the update instead of
+the stale empty IPv4-only state. This topology adds no browser-only VPC to the
+project's network quota.
 
 A manual protected production `mode=plan` reuses current runtime image digests
 and does not build, publish, promote, or apply. Production destroy is not

--- a/terraform/deploy-local.sh
+++ b/terraform/deploy-local.sh
@@ -499,70 +499,6 @@ bootstrap_vault_token() {
   return 1
 }
 
-bootstrap_browser_readiness_ipv6() {
-  local target_workspace="$1"
-  local action="$2"
-
-  # Scoped to preview workspaces only: prod's browser_readiness subnet
-  # already completed this transition in an earlier apply, and prod's apply
-  # sequence is covered by a strict mocked-terraform invocation-order
-  # contract (ci/vault-first-bootstrap-contract_test.sh) that a prod-scoped
-  # extra targeted apply here would need to be taught about.
-  case "$target_workspace" in
-    pr-*) ;;
-    *) return 0 ;;
-  esac
-
-  if [ "$action" != "apply" ] \
-    && { [ "$action" != "plan" ] || [ "${TF_APPLY_PENDING:-}" != "true" ]; }; then
-    return 0
-  fi
-
-  if [ -n "$target_set" ]; then
-    return 0
-  fi
-
-  # The Google provider does not mark external_ipv6_prefix as pending
-  # recomputation when stack_type/ipv6_access_type change in place, so the
-  # postcondition guarding it in readiness.tf evaluates against stale
-  # (pre-transition) state during planning itself -- on every Terraform
-  # invocation, targeted or not, plan or apply, since Terraform always halts
-  # on a failing plan-time postcondition before ever calling the provider's
-  # real update. There is no way to reach a genuine post-apply read through
-  # Terraform alone on an environment's first IPV4_ONLY -> IPV4_IPV6
-  # transition. Instead, read the subnet's existing recorded name straight
-  # from state (a plain state read; no plan, no provider call, no
-  # postcondition) and, only when it still needs the transition, apply it
-  # directly via gcloud so real infrastructure is already migrated by the
-  # time Terraform's own plan runs and refreshes. A no-op once the subnet has
-  # already transitioned, and a no-op when the subnet doesn't exist in state
-  # yet (a brand-new resource is created with the right stack_type/
-  # ipv6_access_type from the start; only the in-place update path hits this
-  # provider gap). TF_APPLY_PENDING scopes this to plan calls CI knows are
-  # immediately followed by a real apply, so a standalone review-only plan
-  # never mutates infrastructure.
-  local subnet_state existing_name existing_stack_type region
-
-  subnet_state="$(terraform show -json 2>/dev/null | jq -r '
-    .values.root_module.resources[]? |
-    select(.address == "google_compute_subnetwork.browser_readiness[0]") |
-    [.values.name, .values.stack_type] | @tsv
-  ')"
-  [ -n "$subnet_state" ] || return 0
-
-  existing_name="$(cut -f1 <<<"$subnet_state")"
-  existing_stack_type="$(cut -f2 <<<"$subnet_state")"
-  [ "$existing_stack_type" != "IPV4_IPV6" ] || return 0
-
-  region="$(resolve_terraform_region)"
-  echo "Transitioning ${existing_name} to dual-stack external IPv6 directly via gcloud before Terraform plans it..." >&2
-  gcloud compute networks subnets update "$existing_name" \
-    --project="$GCLOUD_PROJECT" \
-    --region="$region" \
-    --stack-type=IPV4_IPV6 \
-    --ipv6-access-type=EXTERNAL
-}
-
 vault_token_ready_once() {
   local vault_addr="$1"
   local access_token="$2"
@@ -1083,10 +1019,6 @@ fi
 
 if [ "$action" != "destroy" ]; then
   terraform validate
-fi
-
-if [ "$action" = "plan" ] || [ "$action" = "apply" ]; then
-  bootstrap_browser_readiness_ipv6 "$target_workspace" "$action"
 fi
 
 case "$action" in

--- a/terraform/readiness.tf
+++ b/terraform/readiness.tf
@@ -31,7 +31,7 @@ locals {
   browser_readiness_account_id    = "${trimsuffix(substr("probe-browser-${local.workspace_slug}", 0, 21), "-")}-${local.browser_readiness_name_hash}"
   browser_readiness_network_tag   = "${local.browser_readiness_job_name}-isolated"
   browser_readiness_allowed_ips = local.browser_readiness_enabled ? [
-    google_compute_subnetwork.browser_readiness[0].external_ipv6_prefix,
+    data.google_compute_subnetwork.browser_readiness[0].external_ipv6_prefix,
   ] : []
 }
 
@@ -62,10 +62,27 @@ resource "google_compute_subnetwork" "browser_readiness" {
   stack_type               = "IPV4_IPV6"
   ipv6_access_type         = "EXTERNAL"
   private_ip_google_access = false
+}
+
+# The Google provider preserves the prior empty computed prefix while planning
+# an in-place IPV4_ONLY -> IPV4_IPV6 transition. An explicit dependent read is
+# therefore deferred until apply whenever the subnet changes. Consumers receive
+# an unknown value in the saved plan, then the freshly allocated prefix after
+# the update; the postcondition remains strict on both fresh and stable runs.
+data "google_compute_subnetwork" "browser_readiness" {
+  count = local.browser_readiness_enabled ? 1 : 0
+
+  project = var.project_id
+  region  = var.region
+  name    = google_compute_subnetwork.browser_readiness[0].name
+
+  depends_on = [google_compute_subnetwork.browser_readiness]
 
   lifecycle {
     postcondition {
       condition = (
+        self.stack_type == "IPV4_IPV6" &&
+        self.ipv6_access_type == "EXTERNAL" &&
         can(cidrhost(self.external_ipv6_prefix, 0)) &&
         strcontains(self.external_ipv6_prefix, ":") &&
         endswith(self.external_ipv6_prefix, "/64")


### PR DESCRIPTION
Moves the external IPv6 prefix proof to an apply-deferred subnet read. This lets the trusted preview Terraform base update an existing IPv4-only browser subnet in place, while still failing closed before PPB or browser execution if the newly allocated /64 is invalid. Includes the focused browser-readiness contract and Terraform operations guidance.