### PR TITLE
[minor] Give preview workspaces their own zone, decoupled from production

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,6 +28,7 @@ locals {
   is_prod_workspace          = terraform.workspace == "prod"
   is_preview_workspace       = startswith(terraform.workspace, "pr-")
   cloud_compose_machine_type = local.is_preview_workspace ? var.preview_machine_type : var.machine_type
+  cloud_compose_zone         = local.is_preview_workspace ? var.preview_zone : var.zone
   cloud_compose_disk_type    = local.is_preview_workspace ? "pd-standard" : "hyperdisk-balanced"
   foundation_state_prefix    = "scribe-foundation"
   shared_vault_workspace     = local.is_prod_workspace ? "prod" : "dev"
@@ -804,7 +805,7 @@ module "scribe" {
     project_id     = var.project_id
     project_number = local.project_number
     region         = var.region
-    zone           = var.zone
+    zone           = local.cloud_compose_zone
 
     identity = {
       # cloud-compose 1.7.2 mints and rotates the scribe app SA key into

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,6 +32,17 @@ variable "zone" {
   default     = "us-east5-b"
 }
 
+variable "preview_zone" {
+  description = "GCP zone used only by pull-request preview workspaces, kept independent of the production zone so preview VM creation never competes with production for capacity in the same zone."
+  type        = string
+  default     = "us-east5-b"
+
+  validation {
+    condition     = contains(["us-east5-a", "us-east5-b", "us-east5-c"], var.preview_zone)
+    error_message = "preview_zone must be a reviewed zone within the us-east5 region: us-east5-a, us-east5-b, or us-east5-c."
+  }
+}
+
 variable "machine_type" {
   description = "Compute Engine machine type."
   type        = string


### PR DESCRIPTION
## Summary
- Preview and production VM creation currently share `var.zone`, so a preview apply competes with production for capacity in the same GCP zone. This is why recent preview deploys have failed with "does not have enough resources available" for `us-east5-c`, even though production's own VM was created there successfully just before.
- Adds `preview_zone` (same reviewed-allowlist pattern as the existing `preview_machine_type`) and routes it through a `cloud_compose_zone` local exactly like the existing `cloud_compose_machine_type` split.
- Production is unaffected: for a non-preview workspace, `cloud_compose_zone` still resolves to `var.zone` exactly as before.

## Test plan
- [x] `terraform validate`
- [x] `terraform fmt -check -diff`
- [ ] CI

https://claude.ai/code/session_018E6hG6YKPQNMfE4VohtpHJ