### PR TITLE
Add token substage marker and multi-file upload readiness coverage

### DIFF
--- a/internal/cloudrunreadiness/gcloud.go
+++ b/internal/cloudrunreadiness/gcloud.go
@@ -496,7 +496,7 @@ var (
 	backendNetworkKind   = `((dns-match|dns-mismatch|dns-empty|dns-timeout|dns-error); (tcp-open|tcp-refused|tcp-timeout|tcp-unreachable|tcp-error); ` + backendHTTPKind + `|dns-invalid-origin; tcp-skipped; http-skipped)`
 	backendMarkerPattern = regexp.MustCompile(`^(frontend readiness failed: (frontend-server-exited|frontend did not respond|HTTP [1-5][0-9]{2} \(` + readinessPayloadKind + `\)|transport-` + readinessErrorKind + `|internal-` + readinessErrorKind + `)|frontend proxy request failed \[` + readinessErrorKind + `\]|frontend backend startup gate failed \[` + readinessErrorKind + `; (readiness-contract; HTTP [1-5][0-9]{2} \((invalid-json|invalid-payload|invalid-public-origin|missing-status|ready-payload-with-non-success-http)\)|startup-deadline; (backend did not report ready|HTTP [1-5][0-9]{2} \(` + backendPayloadKind + `\)|transport-` + readinessErrorKind + `))\]|frontend backend network probe \[` + backendNetworkKind + `\])$`)
 	ocrMarkerPattern     = regexp.MustCompile(`^ocr readiness failed: (image-contract|(segment|transcribe|ollama)-(token|request|timeout|contract))$`)
-	browserMarkerPattern = regexp.MustCompile(`^browser readiness failed: (home|context|upload|handoff|transcription|annotations|editor|overlay|retranscribe|structure|save|publish|responsive|token|manifest|cleanup|network|network-(document|auth|workspace|item|context|annotation|processing|transcription|events|presentation|iiif|asset|other)-(client|server)|network-(document|api|events|image|asset|other)-transport|initial-ingress-(forbidden|not-found)|csp|rate)$`)
+	browserMarkerPattern = regexp.MustCompile(`^browser readiness failed: (home|context|upload|upload-multi|handoff|transcription|annotations|editor|overlay|retranscribe|structure|save|publish|responsive|token|manifest|cleanup|network|network-(document|auth|workspace|item|context|annotation|processing|transcription|events|presentation|iiif|asset|other)-(client|server)|network-(document|api|events|image|asset|other)-transport|initial-ingress-(forbidden|not-found)|csp|rate)$`)
 )
 
 var (
@@ -504,6 +504,7 @@ var (
 	browserUploadDurableFailureMarkerPattern    = regexp.MustCompile(`^browser readiness upload durable failure: (segmentation-canceled|segmentation-timeout|segmentation-failed|provider-authentication|provider-failed|admission-failed|upload-storage-failed|segmentation-output-failed|quota-resize-failed|lease-renewal-failed|image-commit-failed|ocr-run-commit-failed|annotation-commit-failed|transcription-enqueue-failed|item-reload-failed|batch-commit-failed|unknown)$`)
 	browserUploadRetryableResponseMarkerPattern = regexp.MustCompile(`^browser readiness upload retryable response: (connect-(aborted|already-exists|deadline-exceeded|internal|resource-exhausted|unavailable|unknown)|http-(408|409|425|429|500|502|503|504))$`)
 	browserStructureSubstageMarkerPattern       = regexp.MustCompile(`^browser readiness structure substage: (draw-mode|centered-line|undo-redo|delete-line|line-edit|split-words|add-word|word-history|join-words|split-line|join-lines|snapshot)$`)
+	browserTokenSubstageMarkerPattern           = regexp.MustCompile(`^browser readiness token substage: (post-home-presentation|settings-open|key-creation|key-display|key-deletion|logout-proof|final-cleanup)$`)
 	browserRateLimitMarkerPattern               = regexp.MustCompile(`^browser readiness rate limit: (document|auth|workspace|item|context|annotation|processing|transcription|events|presentation|iiif|asset|other)$`)
 )
 
@@ -524,6 +525,7 @@ func ReadinessMarkerAllowed(kind Kind, line string) bool {
 			browserUploadDurableFailureMarkerPattern.MatchString(line) ||
 			browserUploadRetryableResponseMarkerPattern.MatchString(line) ||
 			browserStructureSubstageMarkerPattern.MatchString(line) ||
+			browserTokenSubstageMarkerPattern.MatchString(line) ||
 			browserRateLimitMarkerPattern.MatchString(line)
 	default:
 		return false

--- a/internal/cloudrunreadiness/markers_test.go
+++ b/internal/cloudrunreadiness/markers_test.go
@@ -118,6 +118,23 @@ func TestBrowserStructureSubstageMarkerVocabularyIsExhaustive(t *testing.T) {
 	}
 }
 
+func TestBrowserTokenSubstageMarkerVocabularyIsExhaustive(t *testing.T) {
+	t.Parallel()
+	substages := []string{
+		"post-home-presentation", "settings-open", "key-creation", "key-display",
+		"key-deletion", "logout-proof", "final-cleanup",
+	}
+	for _, substage := range substages {
+		line := "browser readiness token substage: " + substage
+		if !ReadinessMarkerAllowed(KindBrowser, line) {
+			t.Errorf("browser token substage %q was rejected", substage)
+		}
+		if ReadinessMarkerAllowed(KindBackend, line) || ReadinessMarkerAllowed(KindOCR, line) {
+			t.Errorf("browser token substage %q crossed kind boundary", substage)
+		}
+	}
+}
+
 func TestBrowserRateLimitMarkerVocabularyIsExhaustive(t *testing.T) {
 	t.Parallel()
 	families := []string{

--- a/web/e2e/deployed-readiness.mjs
+++ b/web/e2e/deployed-readiness.mjs
@@ -79,6 +79,7 @@ const readinessFailureExitCodes = new Map([
   ["home", 21],
   ["context", 22],
   ["upload", 23],
+  ["upload-multi", 74],
   ["handoff", 24],
   ["transcription", 25],
   ["annotations", 26],
@@ -1930,6 +1931,7 @@ let uploadFailureSubstage = "response-contract";
 let uploadDurableFailureCategory;
 let uploadRetryableResponseCategory;
 let structureFailureSubstage = "draw-mode";
+let tokenFailureSubstage = "post-home-presentation";
 let browserFaultMonitoringActive = true;
 let browser;
 let browserContext;
@@ -1945,6 +1947,8 @@ let manifestExternalReferenceID;
 let manifestIdempotencyKey;
 let createdWorkspaceID;
 let fixtureName;
+let multiUploadItemID;
+let multiUploadItemName;
 let createdAPIKeyName;
 let createdAPIKeyID;
 let manifestImportAttempted = false;
@@ -3245,9 +3249,12 @@ try {
   await assertItemDeletePresentation("#shell-content", createdItemID, fixtureName);
   await assertItemDeletePresentation("#shell-sidebar", createdItemID, fixtureName);
   category = "token";
+  tokenFailureSubstage = "post-home-presentation";
   await page.locator("#shell-account-button").click();
+  tokenFailureSubstage = "settings-open";
   await page.getByRole("heading", { name: "Workspace and account settings", exact: true }).waitFor({ state: "visible" });
   await page.locator("#settings-api-key-form").waitFor({ state: "visible" });
+  tokenFailureSubstage = "key-creation";
   createdAPIKeyName = `browser-readiness-${randomUUID()}`;
   await page.getByLabel("Workspace token name").fill(createdAPIKeyName);
   await page.getByLabel("Workspace token role").selectOption("read");
@@ -3278,6 +3285,7 @@ try {
   assertMainScenarioActive();
   tokenMutation.validated = true;
 
+  tokenFailureSubstage = "key-display";
   const tokenDialog = page.getByRole("dialog", { name: "Copy workspace token", exact: true });
   await tokenDialog.waitFor({ state: "visible" });
   const tokenField = tokenDialog.getByRole("textbox", { name: "Workspace token", exact: true });
@@ -3488,12 +3496,63 @@ try {
   );
   assertBrowserHealthy();
 
+  category = "upload-multi";
+  await navigate("/");
+  await page.locator('[data-library-tab="multi"]').click();
+  const multiUploadFixture = exactReadinessSmokeFixture();
+  const multiUploadFixtureNames = [
+    `browser-readiness-${randomUUID()}.png`,
+    `browser-readiness-${randomUUID()}.png`,
+  ];
+  multiUploadItemName = multiUploadFixtureNames[0];
+  assertMainScenarioActive();
+  await page.locator("#library-multi-files").setInputFiles(multiUploadFixtureNames.map((name) => ({
+    name,
+    mimeType: "image/png",
+    buffer: multiUploadFixture,
+  })));
+  const multiUploadStartResponsePromise = page.waitForResponse((response) => (
+    sameOriginConnectResponse(response, "/scribe.v1.ItemService/StartUploadBatch")
+  ), { timeout: uploadRequestTimeoutMs });
+  await page.getByRole("button", { name: "Upload or resume batch", exact: true }).click();
+  const multiUploadStartResponse = await multiUploadStartResponsePromise;
+  if (!multiUploadStartResponse.ok()) throw new Error("multi upload start failed");
+  const multiUploadStartPayload = await responseJSON(multiUploadStartResponse, "invalid multi upload start response");
+  multiUploadItemID = String(multiUploadStartPayload?.item?.id ?? "").trim();
+  if (
+    !multiUploadItemID
+    || multiUploadStartPayload?.item?.name !== multiUploadItemName
+    || multiUploadStartPayload?.item?.sourceType !== "upload"
+  ) {
+    throw new Error("multi upload item identity mismatch");
+  }
+  await page.waitForFunction((expectedFilename) => {
+    const text = document.getElementById("library-multi-status")?.textContent?.trim() ?? "";
+    return text === `Uploaded 2/2: ${expectedFilename}`;
+  }, multiUploadFixtureNames[1], { timeout: uploadRequestTimeoutMs });
+  assertMainScenarioActive();
+  const multiUploadedItem = await getItemForCleanup(multiUploadItemID, createdWorkspaceID, mainScenarioDeadline);
+  const multiUploadedImages = Array.isArray(multiUploadedItem?.images) ? multiUploadedItem.images : [];
+  const multiUploadedImageIDs = new Set(multiUploadedImages.map((image) => positiveID(image?.id)));
+  if (
+    multiUploadedItem?.name !== multiUploadItemName
+    || multiUploadedItem?.sourceType !== "upload"
+    || multiUploadedImages.length !== 2
+    || multiUploadedImageIDs.size !== 2
+    || [...multiUploadedImageIDs].some((imageID) => !imageID)
+  ) {
+    throw new Error("multi upload item did not retain the exact declared image set");
+  }
+  assertBrowserHealthy();
+
   category = "cleanup";
   await navigate("/");
   await deleteItemThroughLibrary("#shell-content", createdItemID, fixtureName);
   createdItemID = undefined;
   await deleteItemThroughLibrary("#shell-sidebar", createdManifestItemID, createdManifestItemName);
   createdManifestItemID = undefined;
+  await deleteItemThroughLibrary("#shell-content", multiUploadItemID, multiUploadItemName);
+  multiUploadItemID = undefined;
   assertBrowserHealthy();
   })();
   await Promise.race([mainScenario, mainScenarioWatchdog]);
@@ -3510,7 +3569,10 @@ try {
       await unlink(productionStorageStatePath);
       productionStorageStateRemoved = true;
     } catch (error) {
-      if (error?.code !== "ENOENT") failureCategory ??= "token";
+      if (error?.code !== "ENOENT") {
+        tokenFailureSubstage = "final-cleanup";
+        failureCategory ??= "token";
+      }
     }
   }
   if (mainScenarioWatchdogTimer !== undefined) {
@@ -3531,7 +3593,7 @@ try {
   if (
     browserContext
     && createdWorkspaceID
-    && (createdAPIKeyName || createdAPIKeyID || fixtureName || manifestImportAttempted)
+    && (createdAPIKeyName || createdAPIKeyID || fixtureName || multiUploadItemName || manifestImportAttempted)
   ) {
     category = "cleanup";
     let cleanupFailed = false;
@@ -3566,6 +3628,7 @@ try {
 
     if (createdAPIKeyName) {
       try {
+        tokenFailureSubstage = "key-deletion";
         await cleanupExactAPIKeys(
           createdAPIKeyName,
           createdWorkspaceID,
@@ -3591,10 +3654,25 @@ try {
       }
     }
 
+    if (multiUploadItemName) {
+      try {
+        await cleanupExactUploadItems(
+          multiUploadItemName,
+          createdWorkspaceID,
+          multiUploadItemID,
+          uploadMutation,
+          globalCleanupDeadline,
+        );
+      } catch {
+        cleanupFailed = true;
+      }
+    }
+
     if (cleanupFailed) failureCategory ??= category;
   }
   if (browserMode === "production" && productionSessionCookie) {
     try {
+      tokenFailureSubstage = "logout-proof";
       await revokeProductionSession(sessionRevocationDeadline);
     } catch {
       failureCategory ??= "token";
@@ -3628,6 +3706,9 @@ if (failureCategory) {
   }
   if (failureCategory === "structure") {
     process.stderr.write(`browser readiness structure substage: ${structureFailureSubstage}\n`);
+  }
+  if (failureCategory === "token") {
+    process.stderr.write(`browser readiness token substage: ${tokenFailureSubstage}\n`);
   }
   if (failureCategory === "rate" && browserFaultRateFamily) {
     process.stderr.write(`browser readiness rate limit: ${browserFaultRateFamily}\n`);


### PR DESCRIPTION
## Summary
- Adds a fixed, allowlisted token substage marker (post-home-presentation, settings-open, key-creation, key-display, key-deletion, logout-proof, final-cleanup) to production browser readiness, mirroring the existing structure substage pattern, so the next failed run pinpoints exactly where the token flow is hanging instead of only reporting "token".
- Adds a golden-path multi-file upload readiness scenario exercising the previously untested `#library-multi-files` batch upload flow, with matching in-scenario and fallback cleanup.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/cloudrunreadiness/...`
- [x] `node --check ./web/e2e/deployed-readiness.mjs`
- [x] `node --test ./web/e2e/deployed-readiness-{budget,dom,structure}.test.mjs ./web/e2e/deployed-readiness-routing_test.mjs`
- [ ] Hosted CI (lint-test / terraform-preview)