### PR TITLE
Migrate compose lifecycle to cloud-compose 1.9.1's checked-program contract

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -208,8 +208,11 @@ locals {
   }
   default_kraken_url      = try(local.kraken_transcription_services[local.kraken_default_transcription_key].primary_url, "")
   default_kraken_audience = try(local.kraken_transcription_services[local.kraken_default_transcription_key].audience, "")
-  docker_compose_services = ["mariadb", "triplet", "api", "worker", "traefik"]
-  compose_traefik_ip      = cidrhost(var.compose_network_cidr, 2)
+  # The compose service list (mariadb, triplet, api, worker, traefik) is baked
+  # directly into terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-compose-pull.sh
+  # and scribe-compose-up.sh, since checked lifecycle programs cannot take
+  # arguments and this list rarely changes. Update both scripts together.
+  compose_traefik_ip = cidrhost(var.compose_network_cidr, 2)
   # Allocate ordinary containers only from the upper half. Traefik's fixed
   # host-2 address remains in the parent subnet but outside Docker's dynamic
   # pool, so parallel Compose startup cannot assign it to another service.
@@ -427,54 +430,50 @@ locals {
       value = var.api_image
     },
     {
-      name  = "VAULT_ADDRESS"
+      # cloud-compose reserves the VAULT_ prefix in extra_env for its own
+      # Vault Agent control-plane keys. scribe-remap-vault-env.sh re-emits
+      # these under the plain VAULT_ names the application expects.
+      name  = "SCRIBE_VAULT_ADDRESS"
       value = local.vault_url
     },
     {
-      name  = "VAULT_WORKSPACE"
+      name  = "SCRIBE_VAULT_WORKSPACE"
       value = local.workspace_slug
     },
     {
-      name  = "VAULT_SECRET_PREFIX"
+      name  = "SCRIBE_VAULT_SECRET_PREFIX"
       value = local.vault_secret_prefix
     },
     {
-      name  = "VAULT_DATABASE_APP_PATH"
+      name  = "SCRIBE_VAULT_DATABASE_APP_PATH"
       value = "${local.vault_secret_prefix}/database/app"
     },
     {
-      name  = "VAULT_GCP_AUTH_ROLE"
+      name  = "SCRIBE_VAULT_GCP_AUTH_ROLE"
       value = local.vault_app_role_name
     },
   ]
-  compose_env_update_commands = [
-    for env in local.compose_env_vars :
-    format(
-      "bash scripts/update-env.sh .env %s --base64 '%s'",
-      env.name,
-      base64encode(env.value),
-    )
+  # cloud-compose >= 1.9.1 rejects lifecycle entries that carry inline shell
+  # commands or arguments; each entry must name one argument-free, root-owned
+  # checked program immediately below /etc/cloud-compose/lifecycle.d (staged
+  # by terraform/rootfs/etc/cloud-compose/lifecycle.d via the rootfs overlay).
+  # Data flows in through extra_env/application-env.json instead of argv.
+  docker_compose_init = [
+    "/etc/cloud-compose/lifecycle.d/scribe-preflight.sh",
   ]
-  docker_compose_init = concat(
-    local.compose_env_update_commands,
-    [
-      "SCRIBE_EXPECTED_DOCKER_ROOT=/mnt/disks/data/docker bash /home/cloud-compose/scribe-compose-runtime-preflight.sh \"$PWD\" \"$PWD/docker-compose.yaml\" /home/cloud-compose/scribe-runtime.compose.yaml",
-    ]
-  )
-  docker_compose_up = concat(
-    local.compose_env_update_commands,
-    [
-      "SCRIBE_EXPECTED_DOCKER_ROOT=/mnt/disks/data/docker bash /home/cloud-compose/scribe-compose-runtime-preflight.sh \"$PWD\" \"$PWD/docker-compose.yaml\" /home/cloud-compose/scribe-runtime.compose.yaml",
-      format("source /home/cloud-compose/profile.sh && retry_until_success docker compose -f docker-compose.yaml -f /home/cloud-compose/scribe-runtime.compose.yaml pull %s", join(" ", local.docker_compose_services)),
-      "SCRIBE_REPAIR_LOCAL_TOKENS=true bash generate-secrets.sh",
-      "SCRIBE_EXPECTED_DOCKER_ROOT=/mnt/disks/data/docker bash /home/cloud-compose/scribe-compose-runtime-preflight.sh --converge \"$PWD\" \"$PWD/docker-compose.yaml\" /home/cloud-compose/scribe-runtime.compose.yaml",
-      format("docker compose -f docker-compose.yaml -f /home/cloud-compose/scribe-runtime.compose.yaml up --no-build --wait --wait-timeout 180 %s", join(" ", local.docker_compose_services)),
-      "curl --noproxy '*' --fail --silent --show-error --connect-timeout 2 --max-time 10 --output /dev/null http://127.0.0.1/readyz",
-    ]
-  )
-  docker_compose_down = concat(local.compose_env_update_commands, [
-    "docker compose -f docker-compose.yaml -f /home/cloud-compose/scribe-runtime.compose.yaml down",
-  ])
+  docker_compose_up = [
+    "/etc/cloud-compose/lifecycle.d/scribe-sync-env.sh",
+    "/etc/cloud-compose/lifecycle.d/scribe-remap-vault-env.sh",
+    "/etc/cloud-compose/lifecycle.d/scribe-preflight.sh",
+    "/etc/cloud-compose/lifecycle.d/scribe-compose-pull.sh",
+    "/etc/cloud-compose/lifecycle.d/scribe-generate-secrets.sh",
+    "/etc/cloud-compose/lifecycle.d/scribe-preflight-converge.sh",
+    "/etc/cloud-compose/lifecycle.d/scribe-compose-up.sh",
+    "/etc/cloud-compose/lifecycle.d/scribe-readyz.sh",
+  ]
+  docker_compose_down = [
+    "/etc/cloud-compose/lifecycle.d/scribe-compose-down.sh",
+  ]
   cloud_compose_power_start_role = try(
     data.terraform_remote_state.shared_foundation.outputs.cloud_compose_power_start_role,
     "",
@@ -874,9 +873,12 @@ module "scribe" {
   runtime = {
     rootfs = "${path.module}/rootfs"
     users  = var.users
-    extra_env = local.is_prod_workspace ? {
-      SCRIBE_MARIADB_BACKUP_MIN_FREE_BYTES = tostring(var.disk_size_gb * 1073741824)
-    } : {}
+    extra_env = merge(
+      { for env in local.compose_env_vars : env.name => env.value },
+      local.is_prod_workspace ? {
+        SCRIBE_MARIADB_BACKUP_MIN_FREE_BYTES = tostring(var.disk_size_gb * 1073741824)
+      } : {},
+    )
 
     compose = {
       primary = "primary"

--- a/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-compose-down.sh
+++ b/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-compose-down.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec docker compose -f docker-compose.yaml -f /home/cloud-compose/scribe-runtime.compose.yaml down

--- a/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-compose-pull.sh
+++ b/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-compose-pull.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source /home/cloud-compose/profile.sh
+retry_until_success docker compose -f docker-compose.yaml -f /home/cloud-compose/scribe-runtime.compose.yaml \
+  pull mariadb triplet api worker traefik

--- a/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-compose-up.sh
+++ b/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-compose-up.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec docker compose -f docker-compose.yaml -f /home/cloud-compose/scribe-runtime.compose.yaml \
+  up --no-build --wait --wait-timeout 180 mariadb triplet api worker traefik

--- a/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-generate-secrets.sh
+++ b/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-generate-secrets.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export SCRIBE_REPAIR_LOCAL_TOKENS=true
+exec bash generate-secrets.sh

--- a/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-preflight-converge.sh
+++ b/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-preflight-converge.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export SCRIBE_EXPECTED_DOCKER_ROOT=/mnt/disks/data/docker
+exec bash /home/cloud-compose/scribe-compose-runtime-preflight.sh \
+  --converge "$PWD" "$PWD/docker-compose.yaml" /home/cloud-compose/scribe-runtime.compose.yaml

--- a/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-preflight.sh
+++ b/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-preflight.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export SCRIBE_EXPECTED_DOCKER_ROOT=/mnt/disks/data/docker
+exec bash /home/cloud-compose/scribe-compose-runtime-preflight.sh \
+  "$PWD" "$PWD/docker-compose.yaml" /home/cloud-compose/scribe-runtime.compose.yaml

--- a/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-readyz.sh
+++ b/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-readyz.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec curl --noproxy '*' --fail --silent --show-error --connect-timeout 2 --max-time 10 \
+  --output /dev/null http://127.0.0.1/readyz

--- a/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-remap-vault-env.sh
+++ b/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-remap-vault-env.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Vault configuration cannot travel through extra_env: cloud-compose reserves
+# the VAULT_ prefix for its own Vault Agent control-plane keys. scribe-sync-env
+# already wrote these under an SCRIBE_VAULT_ prefix via the generic
+# application-env mechanism; re-emit them under the names the application
+# actually expects.
+
+# shellcheck disable=SC1091
+source /home/cloud-compose/profile.sh
+set -a
+# shellcheck disable=SC1091
+source ./.env
+set +a
+
+update_compose_env VAULT_ADDRESS "$SCRIBE_VAULT_ADDRESS"
+update_compose_env VAULT_WORKSPACE "$SCRIBE_VAULT_WORKSPACE"
+update_compose_env VAULT_SECRET_PREFIX "$SCRIBE_VAULT_SECRET_PREFIX"
+update_compose_env VAULT_DATABASE_APP_PATH "$SCRIBE_VAULT_DATABASE_APP_PATH"
+update_compose_env VAULT_GCP_AUTH_ROLE "$SCRIBE_VAULT_GCP_AUTH_ROLE"

--- a/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-sync-env.sh
+++ b/terraform/rootfs/etc/cloud-compose/lifecycle.d/scribe-sync-env.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1091
+source /home/cloud-compose/profile.sh
+
+sync_compose_application_env
+update_compose_env COMPOSE_PROJECT_NAME "$COMPOSE_PROJECT_NAME"
+update_compose_env SITE_NAME "${CLOUD_COMPOSE_INSTANCE_NAME:-${GCP_INSTANCE_NAME:-$APP_NAME}}"
+update_compose_env COMPOSE_BIND_PORT "$COMPOSE_BIND_PORT"


### PR DESCRIPTION
## Summary
- cloud-compose >= 1.9.1 rejects lifecycle entries with inline shell commands/arguments; each must now be an argument-free, root-owned checked program under `/etc/cloud-compose/lifecycle.d`. This is the actual current production blocker (`cloud-compose-bootstrap.service` failing on "Lifecycle entries must name one checked program"), separate from the UID pinning fix already merged in #106.
- Adds 9 checked programs under `terraform/rootfs/etc/cloud-compose/lifecycle.d/`, staged via the existing rootfs overlay (already applies root:root 0755 to `.sh` files).
- Rewrites `docker_compose_init`/`up`/`down` to reference them instead of inline command strings.
- The ~55 application env vars now flow through `extra_env`/`application-env.json` (cloud-compose's own `sync_compose_application_env`) instead of individual `update-env.sh` lifecycle entries.
- The 5 `VAULT_*` vars are renamed to `SCRIBE_VAULT_*` in `extra_env` (cloud-compose reserves the `VAULT_` prefix for its own Vault Agent keys) and remapped back to `VAULT_*` by a dedicated checked program.

## Test plan
- [x] `terraform fmt -check -recursive terraform`
- [x] `terraform -chdir=terraform init -lockfile=readonly` / `validate`
- [x] `terraform -chdir=terraform/foundation init -lockfile=readonly` / `validate`
- [x] `bash -n` on all 9 new lifecycle scripts
- [ ] Real production deploy (this is the actual test — cannot be verified locally, no live GCP access from this environment)